### PR TITLE
Add billing adapter system

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,5 @@
 OPENAI_API_KEY=your-api-key-here
+# Path to billing adapter in 'module:Class' form
+BILLING_ADAPTER=app.billing_adapters.simple:SimpleAdapter
+# Endpoint des MCP-Servers (z.B. für sevDesk)
+MCP_ENDPOINT=http://localhost:8001

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ pip install -r requirements.txt
 # installiert auch uvicorn, den ASGI-Server für FastAPI
 # alternativ: pip install uvicorn
 cp .env.example .env  # OPENAI_API_KEY setzen
+# optional: BILLING_ADAPTER=app.billing_adapters.simple:SimpleAdapter
+# bei Anbindung an sevDesk per MCP:
+# BILLING_ADAPTER=app.billing_adapters.sevdesk_mcp:SevDeskMCPAdapter
+# MCP_ENDPOINT=http://localhost:8001
 uvicorn app.main:app --reload
 ```
 
@@ -21,6 +25,12 @@ eine WAV-Datei an den Endpunkt:
 curl -X POST -F "file=@/pfad/zu/audio.wav" \
   http://127.0.0.1:8000/process-audio/
 ```
+
+Der zu nutzende Rechnungsadapter kann über die Umgebungsvariable
+`BILLING_ADAPTER` angegeben werden. Standardmäßig wird ein Dummy-Adapter
+verwendet, der die Rechnung nur speichert.
+Möchtest du Rechnungen direkt an sevDesk übermitteln, kannst du den
+`SevDeskMCPAdapter` nutzen, der das Model Context Protocol spricht.
 
 Die Antwort enthält das erkannte Transkript, die extrahierten
 Rechnungsdaten sowie Informationen zum Speicherort der Ablage im

--- a/app/billing_adapter.py
+++ b/app/billing_adapter.py
@@ -1,4 +1,53 @@
+from __future__ import annotations
+from abc import ABC, abstractmethod
+from importlib import import_module
+from typing import Optional
+
 from app.models import InvoiceContext
+from app.settings import settings
+
+
+class BillingAdapter(ABC):
+    """Interface for all billing adapters."""
+
+    @abstractmethod
+    def send_invoice(self, invoice: InvoiceContext) -> dict:
+        """Send the given invoice to an external billing system."""
+        raise NotImplementedError
+
+
+class DummyAdapter(BillingAdapter):
+    """Fallback adapter used when no other adapter is configured."""
+
+    def send_invoice(self, invoice: InvoiceContext) -> dict:
+        return {
+            "status": "success",
+            "message": f"Rechnung für {invoice.customer.get('name')} verarbeitet."
+        }
+
+
+def _load_adapter(path: Optional[str]) -> BillingAdapter:
+    """Load adapter specified as 'module:Class'."""
+    if not path:
+        return DummyAdapter()
+    module_name, class_name = path.split(":")
+    module = import_module(module_name)
+    adapter_cls = getattr(module, class_name)
+    if not issubclass(adapter_cls, BillingAdapter):
+        raise TypeError("Adapter must inherit from BillingAdapter")
+    return adapter_cls()
+
+
+_adapter: Optional[BillingAdapter] = None
+
+
+def get_adapter() -> BillingAdapter:
+    global _adapter
+    if _adapter is None:
+        _adapter = _load_adapter(settings.billing_adapter)
+    return _adapter
+
 
 def send_to_billing_system(invoice: InvoiceContext) -> dict:
-    return {"status": "success", "message": f"Rechnung für {invoice.customer['name']} verarbeitet."}
+    adapter = get_adapter()
+    return adapter.send_invoice(invoice)

--- a/app/billing_adapters/sevdesk_mcp.py
+++ b/app/billing_adapters/sevdesk_mcp.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+import requests
+
+from app.billing_adapter import BillingAdapter
+from app.models import InvoiceContext
+from app.settings import settings
+
+class SevDeskMCPAdapter(BillingAdapter):
+    """Send invoices to a SevDesk-compatible MCP server."""
+
+    def __init__(self) -> None:
+        self.endpoint = settings.mcp_endpoint or "http://localhost:8001"
+
+    def send_invoice(self, invoice: InvoiceContext) -> dict:
+        url = f"{self.endpoint.rstrip('/')}/invoice"
+        response = requests.post(url, json=invoice.dict(), timeout=10)
+        response.raise_for_status()
+        return response.json()
+

--- a/app/billing_adapters/simple.py
+++ b/app/billing_adapters/simple.py
@@ -1,0 +1,10 @@
+from app.billing_adapter import BillingAdapter
+from app.models import InvoiceContext
+
+class SimpleAdapter(BillingAdapter):
+    """Example adapter that just echoes the invoice."""
+    def send_invoice(self, invoice: InvoiceContext) -> dict:
+        return {
+            "status": "success",
+            "message": f"Local invoice for {invoice.customer.get('name')} stored."
+        }

--- a/app/settings.py
+++ b/app/settings.py
@@ -1,7 +1,10 @@
-from pydantic import BaseSettings
+import os
+from dataclasses import dataclass
 
-class Settings(BaseSettings):
-    openai_api_key: str
+@dataclass
+class Settings:
+    openai_api_key: str = os.getenv('OPENAI_API_KEY', '')
+    billing_adapter: str | None = os.getenv('BILLING_ADAPTER')
+    mcp_endpoint: str | None = os.getenv('MCP_ENDPOINT')
 
 settings = Settings()
-

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -37,6 +37,7 @@ Entwicklung eines modularen Sprachassistenzsystems, das Telefongespräche mit Ha
 - **Funktionen:**
   - Einbindung über Adapter mit abstrakten Schnittstellen
   - Nutzung modellkonformer Protokolle (MCP) statt hardcoded APIs
+  - Beispieladapter `SevDeskMCPAdapter` kommuniziert über HTTP mit einem MCP-Server
 
 ### 5. Persistenz und Protokollierung
 - **Ziel:** Speicherung aller relevanten Kommunikations- und Rechnungsdaten
@@ -92,6 +93,8 @@ Entwicklung eines modularen Sprachassistenzsystems, das Telefongespräche mit Ha
   - Austauschbarkeit aller Komponenten über definierte Schnittstellen  
   - Unterstützung mehrerer LLMs, STT/TTS-Systeme und API-Anbieter  
   - Adapter/Plugin-Architektur zur Erweiterung
+  - Auswahl des aktiven Adapters über die Umgebungsvariable `BILLING_ADAPTER`
+  - MCP-Server-Adresse über `MCP_ENDPOINT` konfigurierbar
 
 - **Abstraktion der Schnittstellen:**  
   - Klare Trennung zwischen interner Logik und externer Anbindung  


### PR DESCRIPTION
## Summary
- create billing adapter interface with dynamic loader
- add example SimpleAdapter and make adapter configurable via `BILLING_ADAPTER`
- update environment example, spec and README
- switch settings to simple dataclass to avoid pydantic requirement
- add SevDesk adapter using MCP protocol

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68837350a72c832b957d073712497b7c