### PR TITLE
Refactor providers and clarify config

### DIFF
--- a/app/llm_agent.py
+++ b/app/llm_agent.py
@@ -1,11 +1,59 @@
-from openai import OpenAI
+"""LLM-based invoice context extraction."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
 import requests
+from openai import OpenAI
+
 from app.settings import settings
 
 
-def extract_invoice_context(transcript: str) -> str:
-    prompt = f"""
-Du bist ein KI-Assistent für Handwerker. Extrahiere aus folgendem Text eine strukturierte JSON-Rechnung gemäß folgendem Schema:
+class LLMProvider(ABC):
+    """Abstract base class for LLM integrations."""
+
+    @abstractmethod
+    def extract(self, transcript: str) -> str:
+        """Return JSON context extracted from the transcript."""
+        raise NotImplementedError
+
+
+class OpenAIProvider(LLMProvider):
+    """Use OpenAI chat completions API."""
+
+    def extract(self, transcript: str) -> str:
+        client = OpenAI()
+        prompt = _build_prompt(transcript)
+        response = client.chat.completions.create(
+            model=settings.llm_model,
+            messages=[
+                {
+                    "role": "system",
+                    "content": "Du bist ein strukturierter JSON-Extraktor für Handwerker.",
+                },
+                {"role": "user", "content": prompt},
+            ],
+        )
+        return response.choices[0].message.content
+
+
+class OllamaProvider(LLMProvider):
+    """Use a local Ollama server."""
+
+    def extract(self, transcript: str) -> str:
+        prompt = _build_prompt(transcript)
+        url = f"{settings.ollama_base_url.rstrip('/')}/api/generate"
+        resp = requests.post(
+            url,
+            json={"model": settings.llm_model, "prompt": prompt, "stream": False},
+            timeout=60,
+        )
+        resp.raise_for_status()
+        return resp.json().get("response", "")
+
+
+def _build_prompt(transcript: str) -> str:
+    return f"""Du bist ein KI-Assistent für Handwerker. Extrahiere aus folgendem Text eine strukturierte JSON-Rechnung gemäß folgendem Schema:
 
 {{
   "type": "InvoiceContext",
@@ -15,27 +63,19 @@ Du bist ein KI-Assistent für Handwerker. Extrahiere aus folgendem Text eine str
 }}
 
 Text: "{transcript}"
-Nur JSON antworten.
-"""
+Nur JSON antworten."""
+
+
+def _select_provider() -> LLMProvider:
     if settings.llm_provider == "openai":
-        client = OpenAI()
-        response = client.chat.completions.create(
-            model=settings.llm_model,
-            messages=[
-                {"role": "system", "content": "Du bist ein strukturierter JSON-Extraktor für Handwerker."},
-                {"role": "user", "content": prompt},
-            ],
-        )
-        return response.choices[0].message.content
-    elif settings.llm_provider == "ollama":
-        url = f"{settings.ollama_base_url.rstrip('/')}/api/generate"
-        resp = requests.post(
-            url,
-            json={"model": settings.llm_model, "prompt": prompt, "stream": False},
-            timeout=60,
-        )
-        resp.raise_for_status()
-        return resp.json().get("response", "")
-    else:
-        raise ValueError(f"Unsupported LLM_PROVIDER {settings.llm_provider}")
+        return OpenAIProvider()
+    if settings.llm_provider == "ollama":
+        return OllamaProvider()
+    raise ValueError(f"Unsupported LLM_PROVIDER {settings.llm_provider}")
+
+
+def extract_invoice_context(transcript: str) -> str:
+    """Extract structured invoice context from the transcript."""
+    provider = _select_provider()
+    return provider.extract(transcript)
 

--- a/app/tts.py
+++ b/app/tts.py
@@ -1,9 +1,35 @@
+"""Text-to-speech provider abstraction."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
 from io import BytesIO
 from gtts import gTTS
 
 
+class TTSProvider(ABC):
+    """Abstract base class for TTS backends."""
+
+    @abstractmethod
+    def synthesize(self, text: str, lang: str = "de") -> bytes:
+        raise NotImplementedError
+
+
+class GTTSProvider(TTSProvider):
+    """Use gTTS to generate speech."""
+
+    def synthesize(self, text: str, lang: str = "de") -> bytes:
+        tts = gTTS(text=text, lang=lang)
+        fp = BytesIO()
+        tts.write_to_fp(fp)
+        return fp.getvalue()
+
+
+def _select_provider() -> TTSProvider:
+    return GTTSProvider()
+
+
 def text_to_speech(text: str, lang: str = "de") -> bytes:
-    tts = gTTS(text=text, lang=lang)
-    fp = BytesIO()
-    tts.write_to_fp(fp)
-    return fp.getvalue()
+    """Generate speech using the configured provider."""
+    provider = _select_provider()
+    return provider.synthesize(text, lang)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -107,4 +107,17 @@ Entwicklung eines modularen Sprachassistenzsystems, das Telefongespräche mit Ha
 
 - **Protokollierung:**  
   - Vollständige Gesprächshistorie (Text + Audio)  
-  - Revisionssichere Speicherung der generierten Daten (Rechnungen, Kundendaten)
+- Revisionssichere Speicherung der generierten Daten (Rechnungen, Kundendaten)
+
+### Konfiguration
+Die folgenden Umgebungsvariablen steuern die einzelnen Module und erlauben den
+Austausch der Implementierungen:
+
+- `BILLING_ADAPTER` – Pfad zum Rechnungsadapter (`modul:Klasse`)
+- `MCP_ENDPOINT` – Adresse eines MCP-kompatiblen Servers
+- `LLM_PROVIDER` / `LLM_MODEL` – Auswahl und Modellname des LLM (z. B. `openai`,
+  `ollama`)
+- `OLLAMA_BASE_URL` – Basis-URL für einen lokalen Ollama-Server
+- `STT_PROVIDER` / `STT_MODEL` – Backend für Speech‑to‑Text (`openai` oder
+  lokales Kommando)
+- `TELEPHONY_PROVIDER` – Telefonieintegration (`twilio` oder `sipgate`)


### PR DESCRIPTION
## Summary
- refactor STT, LLM and TTS modules to use provider interfaces
- document environment variables in the spec

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68838cb55c98832b8f9672859964ee4a