### PR TITLE
Add tests for config and telephony

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,91 @@
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import importlib
+from fastapi.testclient import TestClient
+import pytest
+
+from app import settings as app_settings
+from app import billing_adapter, telephony
+from app import persistence
+from app.models import InvoiceContext
+
+
+def test_default_billing_adapter(monkeypatch):
+    monkeypatch.setattr(app_settings.settings, "billing_adapter", None)
+    importlib.reload(billing_adapter)
+    invoice = InvoiceContext(type="InvoiceContext", customer={"name": "Max"}, service={}, amount={})
+    result = billing_adapter.send_to_billing_system(invoice)
+    assert result["status"] == "success"
+    assert "Max" in result["message"]
+
+
+def test_env_billing_adapter(monkeypatch):
+    monkeypatch.setattr(app_settings.settings, "billing_adapter", "app.billing_adapters.simple:SimpleAdapter")
+    importlib.reload(billing_adapter)
+    adapter = billing_adapter.get_adapter()
+    from app.billing_adapters.simple import SimpleAdapter
+    assert isinstance(adapter, SimpleAdapter)
+
+
+def test_invalid_billing_adapter(monkeypatch):
+    monkeypatch.setattr(app_settings.settings, "billing_adapter", "app.models:InvoiceContext")
+    importlib.reload(billing_adapter)
+    with pytest.raises(TypeError):
+        billing_adapter.get_adapter()
+
+
+def test_invalid_stt_provider(monkeypatch):
+    from app import transcriber
+    monkeypatch.setattr(app_settings.settings, "stt_provider", "foo")
+    importlib.reload(transcriber)
+    with pytest.raises(ValueError):
+        transcriber._select_provider()
+
+
+def test_invalid_llm_provider(monkeypatch):
+    from app import llm_agent
+    monkeypatch.setattr(app_settings.settings, "llm_provider", "foo")
+    importlib.reload(llm_agent)
+    with pytest.raises(ValueError):
+        llm_agent._select_provider()
+
+
+def test_twilio_voice_endpoint(monkeypatch):
+    monkeypatch.setattr(app_settings.settings, "telephony_provider", "twilio")
+    importlib.reload(telephony)
+    from fastapi import FastAPI
+    app = FastAPI()
+    app.include_router(telephony.router)
+    client = TestClient(app)
+    response = client.post("/twilio/voice")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/xml")
+
+
+def test_sipgate_voice_endpoint(monkeypatch):
+    monkeypatch.setattr(app_settings.settings, "telephony_provider", "sipgate")
+    telephony_mod = importlib.reload(telephony)
+    from fastapi import FastAPI
+    app = FastAPI()
+    app.include_router(telephony_mod.router)
+    client = TestClient(app)
+    response = client.post("/sipgate/voice")
+    assert response.status_code == 200
+    assert response.json().get("record").endswith("/sipgate/recording")
+
+
+def test_store_interaction_unique_dirs(monkeypatch, tmp_path):
+    from datetime import datetime
+    monkeypatch.setattr(persistence, "DATA_DIR", tmp_path)
+    class DummyDT(datetime):
+        @classmethod
+        def utcnow(cls):
+            return datetime(2023, 1, 1, 12, 0, 0)
+    monkeypatch.setattr(persistence, "datetime", DummyDT)
+    invoice = InvoiceContext(type="InvoiceContext", customer={}, service={}, amount={})
+    dir1 = persistence.store_interaction(b"a", "t", invoice)
+    monkeypatch.setattr(DummyDT, "utcnow", classmethod(lambda cls: datetime(2023, 1, 1, 12, 0, 1)))
+    dir2 = persistence.store_interaction(b"b", "t", invoice)
+    assert dir1 != dir2
+


### PR DESCRIPTION
## Summary
- add tests covering default and custom billing adapters
- add provider validation checks and telephony voice endpoints
- ensure persisted sessions have unique directories

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688492822eb8832baa2740cd4a6ea0c5