### PR TITLE
Add MacBook Ollama setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,35 @@ LLM_MODEL=mistral
 ```
 `OLLAMA_BASE_URL` kann bei Bedarf angepasst werden. Danach wie gewohnt `uvicorn` starten und Anfragen an `/process-audio/` senden.
 
+## MacBook Pro: Lokale Ausführung mit Ollama
+Folgende Schritte richten das Projekt auf macOS ein und starten es. Alle Befehle
+können durch Ausführen des beiliegenden Skripts `scripts/run_mac_ollama.sh`
+mit einem Klick ausgeführt werden.
+
+```bash
+# Repository klonen und ins Verzeichnis wechseln
+# git clone <diese-repo-url> handwerker-app
+# cd handwerker-app
+
+# Startskript ausführen
+bash scripts/run_mac_ollama.sh
+```
+
+Das Skript erstellt ein virtuelles Python-Environment, installiert die
+Abhängigkeiten, kopiert bei Bedarf die Beispielkonfiguration und startet
+anschließend den Ollama-Server sowie die FastAPI-Anwendung.
+Bei Bedarf lassen sich die Befehle auch manuell ausführen:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env # OPENAI_API_KEY anpassen
+ollama serve &
+uvicorn app.main:app --reload
+```
+
+
 ## Tests ausführen
 ```bash
 pytest

--- a/scripts/run_mac_ollama.sh
+++ b/scripts/run_mac_ollama.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Schnellstart-Skript für macOS, startet Ollama und die App
+set -e
+
+# virtuelles Environment anlegen, falls nicht vorhanden
+if [ ! -d .venv ]; then
+    python3 -m venv .venv
+fi
+source .venv/bin/activate
+
+pip install -r requirements.txt
+
+# Beispielkonfiguration kopieren, falls .env fehlt
+if [ ! -f .env ]; then
+    cp .env.example .env
+fi
+
+# Ollama-Server im Hintergrund starten
+ollama serve &
+OLLAMA_PID=$!
+
+# FastAPI-Anwendung starten
+uvicorn app.main:app --reload
+
+# beim Beenden auch den Ollama-Server stoppen
+kill $OLLAMA_PID


### PR DESCRIPTION
## Summary
- add script `scripts/run_mac_ollama.sh` for one-click setup on macOS
- document how to run the project locally with Ollama on a MacBook Pro

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688493e60a6c832b948c60c274b33ec9