### PR TITLE
Add Render deployment config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,6 @@ ENV PYTHONUNBUFFERED=1
 
 EXPOSE 8000
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# Render.com setzt die Portnummer über die Umgebungsvariable $PORT.
+# Per "sh -c" können wir die Variable auswerten und sonst auf 8000 zurückfallen.
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/README.md
+++ b/README.md
@@ -105,3 +105,19 @@ uvicorn app.main:app --reload
 pytest
 ```
 
+## Deployment auf Render
+
+Für eine kostengünstige Bereitstellung bietet [Render](https://render.com)
+einen kostenlosen Tarif, der für kleinere Projekte ausreicht. Die
+Anwendung lässt sich dank Dockerfile einfach deployen:
+
+1. Bei Render registrieren und das Repository verknüpfen.
+2. Beim Erstellen eines neuen **Web Service** die Option "Docker"
+   wählen. Render erkennt die Datei `render.yaml` automatisch.
+3. Die in `.env.example` aufgeführten Variablen im Dashboard anlegen.
+4. Nach dem Deploy lauscht die App auf dem von Render vorgegebenen
+   Port (`$PORT`). Der Dockerfile wurde entsprechend angepasst.
+
+Damit läuft der Sprachassistent günstig in der Cloud und kann über die
+öffentliche URL von Render erreicht werden.
+

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,6 @@
+services:
+  - type: web
+    name: handwerker-app
+    env: docker
+    dockerfilePath: Dockerfile
+    plan: free


### PR DESCRIPTION
## Summary
- adjust `Dockerfile` to respect `$PORT`
- add `render.yaml` for Render deployment
- update docs with Render instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688496aaa904832ba09aa67939c1ba5c