### PR TITLE
Add ElevenLabs TTS provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,7 @@ STT_PROVIDER=openai
 STT_MODEL=whisper-1
 # Telephony backend: 'twilio' or 'sipgate'
 TELEPHONY_PROVIDER=twilio
+# Text-to-Speech configuration: 'gtts' or 'elevenlabs'
+TTS_PROVIDER=gtts
+# API key for ElevenLabs if used
+ELEVENLABS_API_KEY=

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ cp .env.example .env  # OPENAI_API_KEY setzen
 # STT_PROVIDER=openai|command
 # STT_MODEL=whisper-1
 # TELEPHONY_PROVIDER=twilio|sipgate
+# TTS_PROVIDER=gtts|elevenlabs
 uvicorn app.main:app --reload
 ```
 

--- a/app/settings.py
+++ b/app/settings.py
@@ -12,5 +12,7 @@ class Settings:
     stt_provider: str = os.getenv('STT_PROVIDER', 'openai')
     stt_model: str = os.getenv('STT_MODEL', 'whisper-1')
     telephony_provider: str = os.getenv('TELEPHONY_PROVIDER', 'twilio')
+    tts_provider: str = os.getenv('TTS_PROVIDER', 'gtts')
+    elevenlabs_api_key: str | None = os.getenv('ELEVENLABS_API_KEY')
 
 settings = Settings()

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ twilio
 gtts
 requests
 pytest
+elevenlabs

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -195,8 +195,20 @@ def test_text_to_speech(monkeypatch):
         def write_to_fp(self, fp):
             fp.write(b"mp3")
 
+    monkeypatch.setattr(tts.settings, "tts_provider", "gtts")
     monkeypatch.setattr(tts, "gTTS", DummyTTS)
     result = tts.text_to_speech("hallo")
+    assert result == b"mp3"
+
+
+def test_text_to_speech_elevenlabs(monkeypatch):
+    """Converts text using ElevenLabs"""
+
+    monkeypatch.setattr(tts.settings, "tts_provider", "elevenlabs")
+    monkeypatch.setattr(tts.settings, "elevenlabs_api_key", "k")
+    monkeypatch.setattr(tts, "set_api_key", lambda key: None)
+    monkeypatch.setattr(tts, "generate", lambda **kw: b"mp3")
+    result = tts.text_to_speech("hi")
     assert result == b"mp3"
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -56,6 +56,15 @@ def test_invalid_llm_provider(monkeypatch):
         llm_agent._select_provider()
 
 
+def test_invalid_tts_provider(monkeypatch):
+    """Rejects invalid TTS provider configuration"""
+    from app import tts
+    monkeypatch.setattr(app_settings.settings, "tts_provider", "foo")
+    importlib.reload(tts)
+    with pytest.raises(ValueError):
+        tts._select_provider()
+
+
 def test_twilio_voice_endpoint(monkeypatch):
     """Returns XML for Twilio voice webhooks"""
     monkeypatch.setattr(app_settings.settings, "telephony_provider", "twilio")


### PR DESCRIPTION
## Summary
- introduce new `TTS_PROVIDER` and `ELEVENLABS_API_KEY` settings
- implement ElevenLabs-based speech synthesis
- document new config in README and `.env.example`
- support ElevenLabs in tests and add validation of invalid TTS provider
- add dependency on `elevenlabs`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884d83d2dd0832bb468e18ff75b2158