### PR TITLE
Fix ElevenLabs TTS tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,7 @@ STT_PROVIDER=openai
 STT_MODEL=whisper-1
 # Telephony backend: 'twilio' or 'sipgate'
 TELEPHONY_PROVIDER=twilio
+# Text-to-Speech configuration: 'gtts' or 'elevenlabs'
+TTS_PROVIDER=gtts
+# API key for ElevenLabs if used
+ELEVENLABS_API_KEY=

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ cp .env.example .env  # OPENAI_API_KEY setzen
 # STT_PROVIDER=openai|command
 # STT_MODEL=whisper-1
 # TELEPHONY_PROVIDER=twilio|sipgate
+# TTS_PROVIDER=gtts|elevenlabs
 uvicorn app.main:app --reload
 ```
 

--- a/app/settings.py
+++ b/app/settings.py
@@ -12,5 +12,7 @@ class Settings:
     stt_provider: str = os.getenv('STT_PROVIDER', 'openai')
     stt_model: str = os.getenv('STT_MODEL', 'whisper-1')
     telephony_provider: str = os.getenv('TELEPHONY_PROVIDER', 'twilio')
+    tts_provider: str = os.getenv('TTS_PROVIDER', 'gtts')
+    elevenlabs_api_key: str | None = os.getenv('ELEVENLABS_API_KEY')
 
 settings = Settings()

--- a/app/tts.py
+++ b/app/tts.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from io import BytesIO
 from gtts import gTTS
+from elevenlabs.client import ElevenLabs
+
+from app.settings import settings
 
 
 class TTSProvider(ABC):
@@ -25,8 +28,30 @@ class GTTSProvider(TTSProvider):
         return fp.getvalue()
 
 
+class ElevenLabsProvider(TTSProvider):
+    """Use ElevenLabs API to generate speech."""
+
+    def synthesize(self, text: str, lang: str = "de") -> bytes:
+        if not settings.elevenlabs_api_key:
+            raise ValueError("ELEVENLABS_API_KEY not set")
+
+        client = ElevenLabs(api_key=settings.elevenlabs_api_key)
+        audio_iter = client.text_to_speech.convert(
+            voice_id="Mats",
+            text=text,
+            model_id="eleven_monolingual_v1",
+            language_code=lang,
+            output_format="mp3_44100_128",
+        )
+        return b"".join(audio_iter)
+
+
 def _select_provider() -> TTSProvider:
-    return GTTSProvider()
+    if settings.tts_provider == "gtts":
+        return GTTSProvider()
+    if settings.tts_provider == "elevenlabs":
+        return ElevenLabsProvider()
+    raise ValueError(f"Unsupported TTS_PROVIDER {settings.tts_provider}")
 
 
 def text_to_speech(text: str, lang: str = "de") -> bytes:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ twilio
 gtts
 requests
 pytest
+elevenlabs

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -195,8 +195,28 @@ def test_text_to_speech(monkeypatch):
         def write_to_fp(self, fp):
             fp.write(b"mp3")
 
+    monkeypatch.setattr(tts.settings, "tts_provider", "gtts")
     monkeypatch.setattr(tts, "gTTS", DummyTTS)
     result = tts.text_to_speech("hallo")
+    assert result == b"mp3"
+
+
+def test_text_to_speech_elevenlabs(monkeypatch):
+    """Converts text using ElevenLabs"""
+
+    monkeypatch.setattr(tts.settings, "tts_provider", "elevenlabs")
+    monkeypatch.setattr(tts.settings, "elevenlabs_api_key", "k")
+
+    class DummyClient:
+        def __init__(self, api_key=None):
+            self.api_key = api_key
+            self.text_to_speech = self
+
+        def convert(self, *args, **kwargs):
+            return [b"mp3"]
+
+    monkeypatch.setattr(tts, "ElevenLabs", DummyClient)
+    result = tts.text_to_speech("hi")
     assert result == b"mp3"
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -56,6 +56,15 @@ def test_invalid_llm_provider(monkeypatch):
         llm_agent._select_provider()
 
 
+def test_invalid_tts_provider(monkeypatch):
+    """Rejects invalid TTS provider configuration"""
+    from app import tts
+    monkeypatch.setattr(app_settings.settings, "tts_provider", "foo")
+    importlib.reload(tts)
+    with pytest.raises(ValueError):
+        tts._select_provider()
+
+
 def test_twilio_voice_endpoint(monkeypatch):
     """Returns XML for Twilio voice webhooks"""
     monkeypatch.setattr(app_settings.settings, "telephony_provider", "twilio")


### PR DESCRIPTION
## Summary
- update ElevenLabs TTS implementation to use official client
- adapt ElevenLabs unit test for new API

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6884d83d2dd0832bb468e18ff75b2158