### PR TITLE
Refactor providers and add integration tests

### DIFF
--- a/app/billing_adapters/sevdesk_mcp.py
+++ b/app/billing_adapters/sevdesk_mcp.py
@@ -13,7 +13,7 @@ class SevDeskMCPAdapter(BillingAdapter):
 
     def send_invoice(self, invoice: InvoiceContext) -> dict:
         url = f"{self.endpoint.rstrip('/')}/invoice"
-        response = requests.post(url, json=invoice.dict(), timeout=10)
+        response = requests.post(url, json=invoice.model_dump(), timeout=10)
         response.raise_for_status()
         return response.json()
 

--- a/app/llm_agent.py
+++ b/app/llm_agent.py
@@ -66,12 +66,18 @@ Text: "{transcript}"
 Nur JSON antworten."""
 
 
+_LLM_PROVIDERS: dict[str, type[LLMProvider]] = {
+    "openai": OpenAIProvider,
+    "ollama": OllamaProvider,
+}
+
+
 def _select_provider() -> LLMProvider:
-    if settings.llm_provider == "openai":
-        return OpenAIProvider()
-    if settings.llm_provider == "ollama":
-        return OllamaProvider()
-    raise ValueError(f"Unsupported LLM_PROVIDER {settings.llm_provider}")
+    try:
+        provider_cls = _LLM_PROVIDERS[settings.llm_provider]
+    except KeyError:  # pragma: no cover - configuration error
+        raise ValueError(f"Unsupported LLM_PROVIDER {settings.llm_provider}")
+    return provider_cls()
 
 
 def extract_invoice_context(transcript: str) -> str:

--- a/app/main.py
+++ b/app/main.py
@@ -38,7 +38,7 @@ async def process_audio(file: UploadFile = File(...)):
     log_dir = store_interaction(audio_bytes, transcript, invoice)
     return {
         "transcript": transcript,
-        "invoice": invoice.dict(),
+        "invoice": invoice.model_dump(),
         "billing_result": result,
         "log_dir": log_dir,
     }

--- a/app/persistence.py
+++ b/app/persistence.py
@@ -13,5 +13,5 @@ def store_interaction(audio: bytes, transcript: str, invoice: InvoiceContext) ->
     session_dir.mkdir(parents=True, exist_ok=True)
     (session_dir / "audio.wav").write_bytes(audio)
     (session_dir / "transcript.txt").write_text(transcript, encoding="utf-8")
-    (session_dir / "invoice.json").write_text(json.dumps(invoice.dict(), ensure_ascii=False, indent=2), encoding="utf-8")
+    (session_dir / "invoice.json").write_text(json.dumps(invoice.model_dump(), ensure_ascii=False, indent=2), encoding="utf-8")
     return str(session_dir)

--- a/app/transcriber.py
+++ b/app/transcriber.py
@@ -52,12 +52,18 @@ class CommandTranscriber(STTProvider):
         return result.stdout.strip()
 
 
+_STT_PROVIDERS: dict[str, type[STTProvider]] = {
+    "openai": OpenAITranscriber,
+    "command": CommandTranscriber,
+}
+
+
 def _select_provider() -> STTProvider:
-    if settings.stt_provider == "openai":
-        return OpenAITranscriber()
-    if settings.stt_provider == "command":
-        return CommandTranscriber()
-    raise ValueError(f"Unsupported STT_PROVIDER {settings.stt_provider}")
+    try:
+        provider_cls = _STT_PROVIDERS[settings.stt_provider]
+    except KeyError:  # pragma: no cover - configuration error
+        raise ValueError(f"Unsupported STT_PROVIDER {settings.stt_provider}")
+    return provider_cls()
 
 
 def transcribe_audio(audio_bytes: bytes) -> str:

--- a/app/tts.py
+++ b/app/tts.py
@@ -46,12 +46,18 @@ class ElevenLabsProvider(TTSProvider):
         return b"".join(audio_iter)
 
 
+_TTS_PROVIDERS: dict[str, type[TTSProvider]] = {
+    "gtts": GTTSProvider,
+    "elevenlabs": ElevenLabsProvider,
+}
+
+
 def _select_provider() -> TTSProvider:
-    if settings.tts_provider == "gtts":
-        return GTTSProvider()
-    if settings.tts_provider == "elevenlabs":
-        return ElevenLabsProvider()
-    raise ValueError(f"Unsupported TTS_PROVIDER {settings.tts_provider}")
+    try:
+        provider_cls = _TTS_PROVIDERS[settings.tts_provider]
+    except KeyError:  # pragma: no cover - configuration error
+        raise ValueError(f"Unsupported TTS_PROVIDER {settings.tts_provider}")
+    return provider_cls()
 
 
 def text_to_speech(text: str, lang: str = "de") -> bytes:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,11 @@
 import logging
 import inspect
+import sys
+import os
 import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from app import persistence
 
 @pytest.fixture(autouse=True)
 def log_test_start(request):
@@ -12,3 +17,11 @@ def log_test_start(request):
         logging.info(f"START {request.node.name}")
     yield
     logging.info(f"END {request.node.name}")
+
+
+@pytest.fixture
+def tmp_data_dir(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    monkeypatch.setattr(persistence, "DATA_DIR", data_dir)
+    data_dir.mkdir()
+    yield data_dir

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -70,13 +70,6 @@ class DummyOpenAI:
     def chat(self):
         return DummyOpenAI.Chat(self)
 
-@pytest.fixture
-
-def tmp_data_dir(tmp_path, monkeypatch):
-    data_dir = tmp_path / "data"
-    monkeypatch.setattr(persistence, "DATA_DIR", data_dir)
-    data_dir.mkdir()
-    yield data_dir
 
 
 def test_transcribe_audio(monkeypatch):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,95 @@
+import json
+from pathlib import Path
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app import transcriber, llm_agent, persistence
+from app import settings as app_settings
+from app.models import InvoiceContext
+
+
+class DummyResponse:
+    def __init__(self, text):
+        self.text = text
+
+
+class DummyChatResponse:
+    class DummyChoice:
+        class DummyMessage:
+            def __init__(self, content):
+                self.content = content
+
+        def __init__(self, content):
+            self.message = DummyChatResponse.DummyChoice.DummyMessage(content)
+
+    def __init__(self, content):
+        self.choices = [DummyChatResponse.DummyChoice(content)]
+
+
+class DummyOpenAI:
+    def __init__(self, result):
+        self.result = result
+
+    class Audio:
+        def __init__(self, parent):
+            self.parent = parent
+
+        class Transcriptions:
+            def __init__(self, parent):
+                self.parent = parent
+
+            def create(self, **kwargs):
+                return DummyResponse(self.parent.parent.result)
+
+        @property
+        def transcriptions(self):
+            return DummyOpenAI.Audio.Transcriptions(self)
+
+    class Chat:
+        def __init__(self, parent):
+            self.parent = parent
+
+        class Completions:
+            def __init__(self, parent):
+                self.parent = parent
+
+            def create(self, **kwargs):
+                return DummyChatResponse(self.parent.parent.result)
+
+        @property
+        def completions(self):
+            return DummyOpenAI.Chat.Completions(self)
+
+    @property
+    def audio(self):
+        return DummyOpenAI.Audio(self)
+
+    @property
+    def chat(self):
+        return DummyOpenAI.Chat(self)
+
+
+def test_end_to_end(monkeypatch, tmp_data_dir):
+    """Full pipeline via /process-audio/ endpoint."""
+    monkeypatch.setattr(transcriber.settings, "stt_provider", "openai")
+    monkeypatch.setattr(transcriber.settings, "stt_model", "whisper-1")
+    monkeypatch.setattr(transcriber, "OpenAI", lambda: DummyOpenAI("transcript"))
+
+    dummy_json = json.dumps({
+        "type": "InvoiceContext",
+        "customer": {"name": "Anna"},
+        "service": {"description": "paint", "materialIncluded": True},
+        "amount": {"total": 50.0, "currency": "EUR"},
+    })
+    monkeypatch.setattr(llm_agent.settings, "llm_provider", "openai")
+    monkeypatch.setattr(llm_agent.settings, "llm_model", "gpt-4o")
+    monkeypatch.setattr(llm_agent, "OpenAI", lambda: DummyOpenAI(dummy_json))
+
+    monkeypatch.setattr(app_settings.settings, "billing_adapter", None)
+
+    client = TestClient(app)
+    response = client.post("/process-audio/", files={"file": ("audio.wav", b"data")})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["invoice"]["customer"]["name"] == "Anna"
+    assert Path(data["log_dir"]).exists()


### PR DESCRIPTION
## Summary
- replace `dict()` calls with `model_dump()` when serialising `InvoiceContext`
- refactor STT, LLM and TTS provider selection to use mappings
- update sevDesk MCP adapter
- add integration test exercising the whole `/process-audio/` pipeline
- share `tmp_data_dir` fixture across tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884e82aa58c832b881f83d27569d89c