### PR TITLE
Update docs for additional Ollama models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,8 @@ LLM_PROVIDER=ollama
 # Model name for the chosen provider
 LLM_MODEL=mistral
 # Für lokale Ollama-Nutzung empfehlen wir das Modell "mistral"
+# Alternativ können Modelle wie "llama3", "orca2" oder "deepseek-r1" verwendet
+# werden, die jedoch mehr Ressourcen benötigen
 # Base URL for Ollama server
 OLLAMA_BASE_URL=http://localhost:11434
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ cp .env.example .env  # bei lokaler Nutzung ist kein OPENAI_API_KEY nötig
 # BILLING_ADAPTER=app.billing_adapters.sevdesk_mcp:SevDeskMCPAdapter
 # MCP_ENDPOINT=http://localhost:8001
 # LLM_PROVIDER=ollama|openai
-# LLM_MODEL=mistral
+# LLM_MODEL=mistral  # alternativ: llama3, orca2, deepseek-r1
 # STT_PROVIDER=whisper|openai|command
 # STT_MODEL=base
 # TELEPHONY_PROVIDER=twilio|sipgate
@@ -73,7 +73,7 @@ Dann in der `.env` folgende Einstellungen setzen:
 LLM_PROVIDER=ollama
 LLM_MODEL=mistral
 ```
-Das kompakte Modell `mistral` (z.B. `mistral:latest`) liefert gute Ergebnisse bei geringem Ressourcenverbrauch und eignet sich daher besonders für dieses Projekt.
+Das kompakte Modell `mistral` (z.B. `mistral:latest`) liefert gute Ergebnisse bei geringem Ressourcenverbrauch und eignet sich daher besonders für dieses Projekt. Größere Modelle wie `llama3:latest`, `deepseek-r1:latest` oder `orca2:latest` sind ebenfalls nutzbar, benötigen aber deutlich mehr Ressourcen.
 `OLLAMA_BASE_URL` kann bei Bedarf angepasst werden. Danach wie gewohnt `uvicorn` starten und Anfragen an `/process-audio/` senden.
 
 ## MacBook Pro: Lokale Ausführung mit Ollama

--- a/scripts/run_mac_ollama.sh
+++ b/scripts/run_mac_ollama.sh
@@ -17,7 +17,7 @@ fi
 
 # Lokale Provider verwenden
 export LLM_PROVIDER=ollama
-export LLM_MODEL=${LLM_MODEL:-mistral}
+export LLM_MODEL=${LLM_MODEL:-mistral}  # "llama3" oder "orca2" funktionieren ebenfalls
 export STT_PROVIDER=whisper
 export STT_MODEL=${STT_MODEL:-base}
 


### PR DESCRIPTION
## Summary
- document alternative Ollama models in README and `.env.example`
- mention optional models in macOS helper script

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68873ba5776c832bb29090e10a7c76db