### PR TITLE
Fix missing numpy dependency for whisper

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Bei Bedarf lassen sich die Befehle auch manuell ausführen:
 python3 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
+# numpy ist erforderlich, wenn STT_PROVIDER=whisper verwendet wird
 cp .env.example .env
 ollama serve &
 export LLM_PROVIDER=ollama

--- a/app/transcriber.py
+++ b/app/transcriber.py
@@ -9,7 +9,6 @@ import shlex
 import subprocess
 import tempfile
 from openai import OpenAI
-import whisper
 
 from app.settings import settings
 
@@ -59,6 +58,9 @@ class WhisperTranscriber(STTProvider):
     _model_cache: dict[str, "whisper.Whisper"] = {}
 
     def __init__(self) -> None:
+        # Lazy import to avoid mandatory dependency during test runs
+        import whisper  # type: ignore
+
         if settings.stt_model not in self._model_cache:
             self._model_cache[settings.stt_model] = whisper.load_model(settings.stt_model)
         self.model = self._model_cache[settings.stt_model]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ requests
 pytest
 elevenlabs
 openai-whisper
+numpy


### PR DESCRIPTION
## Summary
- avoid importing `whisper` unless the provider is actually used
- add `numpy` to requirements
- document numpy requirement in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688752dc8dfc832b9fbe816deb3c27bb