### PR TITLE
Auto fallback to OpenAI STT

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,13 +93,16 @@ bash scripts/run_mac_ollama.sh
 Das Skript erstellt ein virtuelles Python-Environment, installiert die
 Abhängigkeiten, kopiert bei Bedarf die Beispielkonfiguration und startet
 anschließend den Ollama-Server sowie die FastAPI-Anwendung.
+Fehlt NumPy, setzt das Skript automatisch `STT_PROVIDER=openai`.
 Bei Bedarf lassen sich die Befehle auch manuell ausführen:
 
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
-# numpy ist erforderlich, wenn STT_PROVIDER=whisper verwendet wird
+# NumPy ist erforderlich, wenn STT_PROVIDER=whisper verwendet wird.
+# Das Startskript wechselt bei fehlendem NumPy automatisch zu
+# STT_PROVIDER=openai.
 cp .env.example .env
 ollama serve &
 export LLM_PROVIDER=ollama
@@ -144,3 +147,21 @@ OpenAI-Provider. Achte darauf, deinen `OPENAI_API_KEY` in der `.env`
 zu hinterlegen. Danach ist die Weboberfläche unter
 `http://localhost:8000/web` erreichbar und es lassen sich wie gewohnt
 Audioaufnahmen hochladen.
+
+## Fehlerbehebung
+
+### "Numpy is not available"
+
+Beim Einsatz des lokalen Whisper-Modells (``STT_PROVIDER=whisper``) muss
+``numpy`` installiert sein. Erscheint beim Start die Meldung
+``RuntimeError: Numpy is not available``, fehlt das Paket in der aktuellen
+Umgebung. Installiere es nachträglich mit:
+
+```bash
+pip install numpy
+```
+
+Alternativ kann ``STT_PROVIDER=openai`` gesetzt werden, um das Whisper-Modell
+von OpenAI zu verwenden, das ohne lokales ``numpy`` auskommt. Wird das
+Startskript verwendet und NumPy fehlt, erfolgt dieser Wechsel inzwischen
+automatisch.

--- a/scripts/run_mac_ollama.sh
+++ b/scripts/run_mac_ollama.sh
@@ -18,7 +18,23 @@ fi
 # Lokale Provider verwenden
 export LLM_PROVIDER=ollama
 export LLM_MODEL=${LLM_MODEL:-mistral}  # "llama3" oder "orca2" funktionieren ebenfalls
-export STT_PROVIDER=whisper
+
+# STT_PROVIDER auf "whisper" setzen, falls nicht anders angegeben.
+STT_PROVIDER_DEFAULT=${STT_PROVIDER:-whisper}
+
+# Falls "whisper" gewählt ist und NumPy fehlt, zum OpenAI-Provider wechseln.
+if [ "$STT_PROVIDER_DEFAULT" = "whisper" ]; then
+    if ! python3 - <<'EOF' >/dev/null 2>&1
+import importlib.util, sys
+sys.exit(0 if importlib.util.find_spec("numpy") else 1)
+EOF
+    then
+        echo "NumPy nicht gefunden, STT_PROVIDER=openai wird verwendet." >&2
+        STT_PROVIDER_DEFAULT="openai"
+    fi
+fi
+
+export STT_PROVIDER=$STT_PROVIDER_DEFAULT
 export STT_MODEL=${STT_MODEL:-base}
 
 # Ollama-Server im Hintergrund starten

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -106,3 +106,24 @@ def test_store_interaction_unique_dirs(monkeypatch, tmp_path):
     dir2 = persistence.store_interaction(b"b", "t", invoice)
     assert dir1 != dir2
 
+
+def test_fallback_to_openai_when_numpy_missing(monkeypatch):
+    """Uses OpenAI STT if NumPy is not installed for Whisper."""
+    import importlib
+    import importlib.util
+    from app import transcriber
+
+    monkeypatch.setattr(app_settings.settings, "stt_provider", "whisper")
+
+    orig_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name, *args, **kwargs):
+        if name == "numpy":
+            return None
+        return orig_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+    importlib.reload(transcriber)
+    provider = transcriber._select_provider()
+    assert isinstance(provider, transcriber.OpenAITranscriber)
+


### PR DESCRIPTION
## Summary
- automatically fall back to OpenAI STT when NumPy is missing
- clarify fallback in README
- test the new fallback logic

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888e9e67408832bb5d0822b5a7b9543