### PR TITLE
Use deepseek-r1 default model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,10 +7,10 @@ MCP_ENDPOINT=http://localhost:8001
 # LLM configuration: 'openai' or 'ollama'
 LLM_PROVIDER=ollama
 # Model name for the chosen provider
-LLM_MODEL=mistral
-# Für lokale Ollama-Nutzung empfehlen wir das Modell "mistral"
-# Alternativ können Modelle wie "llama3", "orca2" oder "deepseek-r1" verwendet
-# werden, die jedoch mehr Ressourcen benötigen
+LLM_MODEL=deepseek-r1:latest
+# Für lokale Ollama-Nutzung empfehlen wir das Modell "deepseek-r1:latest"
+# Alternativ können kleinere Modelle wie "mistral", "llama3" oder "orca2" verwendet
+# werden, die weniger Ressourcen benötigen
 # Base URL for Ollama server
 OLLAMA_BASE_URL=http://localhost:11434
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ cp .env.example .env  # bei lokaler Nutzung ist kein OPENAI_API_KEY nötig
 # BILLING_ADAPTER=app.billing_adapters.sevdesk_mcp:SevDeskMCPAdapter
 # MCP_ENDPOINT=http://localhost:8001
 # LLM_PROVIDER=ollama|openai
-# LLM_MODEL=mistral  # alternativ: llama3, orca2, deepseek-r1
+# LLM_MODEL=deepseek-r1:latest  # alternativ: llama3, orca2, mistral
 # STT_PROVIDER=whisper|openai|command
 # Für whisper/command muss ffmpeg als System-Binary installiert sein
 # z.B. "brew install ffmpeg" (macOS) oder "sudo apt install ffmpeg" (Ubuntu)
@@ -73,9 +73,9 @@ ollama serve &
 Dann in der `.env` folgende Einstellungen setzen:
 ```bash
 LLM_PROVIDER=ollama
-LLM_MODEL=mistral
+LLM_MODEL=deepseek-r1:latest
 ```
-Das kompakte Modell `mistral` (z.B. `mistral:latest`) liefert gute Ergebnisse bei geringem Ressourcenverbrauch und eignet sich daher besonders für dieses Projekt. Größere Modelle wie `llama3:latest`, `deepseek-r1:latest` oder `orca2:latest` sind ebenfalls nutzbar, benötigen aber deutlich mehr Ressourcen.
+Das Modell `deepseek-r1:latest` liefert leistungsfähige Ergebnisse. Kleinere Modelle wie `mistral:latest`, `llama3:latest` oder `orca2:latest` funktionieren ebenfalls und benötigen weniger Ressourcen.
 `OLLAMA_BASE_URL` kann bei Bedarf angepasst werden. Danach wie gewohnt `uvicorn` starten und Anfragen an `/process-audio/` senden.
 
 ## MacBook Pro: Lokale Ausführung mit Ollama

--- a/scripts/run_mac_ollama.sh
+++ b/scripts/run_mac_ollama.sh
@@ -17,7 +17,7 @@ fi
 
 # Lokale Provider verwenden
 export LLM_PROVIDER=ollama
-export LLM_MODEL=${LLM_MODEL:-mistral}  # "llama3" oder "orca2" funktionieren ebenfalls
+export LLM_MODEL=${LLM_MODEL:-deepseek-r1:latest}  # "mistral", "llama3" oder "orca2" funktionieren ebenfalls
 
 # STT_PROVIDER auf "whisper" setzen, falls nicht anders angegeben.
 STT_PROVIDER_DEFAULT=${STT_PROVIDER:-whisper}


### PR DESCRIPTION
## Summary
- default Ollama model changed to `deepseek-r1:latest`
- document new model in README and environment example

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895ba70b024832bbeb8ee000d9a8211