### PR TITLE
Handle LLM JSON wrappers

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,5 +1,6 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 import json
+import re
 
 
 class InvoiceContext(BaseModel):
@@ -16,9 +17,19 @@ def parse_invoice_context(invoice_json: str) -> "InvoiceContext":
     """
     if not invoice_json or not invoice_json.strip():
         raise ValueError("empty invoice context")
+
+    cleaned = invoice_json.strip()
+
+    # Allow LLM responses wrapped in markdown code fences or additional text.
+    match = re.search(r"\{.*\}", cleaned, re.DOTALL)
+    if match:
+        cleaned = match.group(0)
     try:
-        data = json.loads(invoice_json)
+        data = json.loads(cleaned)
     except json.JSONDecodeError as exc:  # pragma: no cover - defensive
         raise ValueError("invalid invoice context") from exc
-    return InvoiceContext(**data)
+    try:
+        return InvoiceContext(**data)
+    except ValidationError as exc:  # pragma: no cover - defensive
+        raise ValueError("invalid invoice context") from exc
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,14 @@
+import pytest
+
+from app.models import parse_invoice_context
+
+
+def test_parse_invoice_context_code_fence():
+    raw = """```json\n{\n  \"type\": \"InvoiceContext\",\n  \"customer\": {},\n  \"service\": {},\n  \"amount\": {}\n}\n```"""
+    invoice = parse_invoice_context(raw)
+    assert invoice.type == "InvoiceContext"
+
+
+def test_parse_invoice_context_invalid():
+    with pytest.raises(ValueError):
+        parse_invoice_context("not json")


### PR DESCRIPTION
## Summary
- sanitize LLM invoice context responses by stripping code fences and validating with Pydantic
- test parsing behavior, including handling fenced JSON and invalid input

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895efecc76c832b8107ce66be3ea024