### PR TITLE
Support itemized e‑invoices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Sprachassistent für Handwerker
 
 Ein FastAPI-basiertes Backend, das Sprache in strukturierte Rechnungsdaten umwandelt und diese an ein Rechnungssystem weiterreicht.
+Es erzeugt positionsgenaue E-Rechnungen nach EN 16931 (z. B. XRechnung/ZUGFeRD) mit Material-, Anfahrts- und Arbeitszeitposten
+inklusive unterschiedlicher Stundensätze für Gesellen und Meister.
 
 ## Start
 Uvicorn ist ein schlanker ASGI-Server, mit dem die FastAPI-Anwendung gestartet

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -46,6 +46,11 @@ Entwicklung eines modularen Sprachassistenzsystems, das Telefongespräche mit Ha
   - Revisionssicheres Logging (z. B. Audit-Trail)
   - Optionale Langzeitspeicherung / Archivierung (DSGVO-konform)
 
+### E-Rechnung nach EN 16931
+- Elektronische Rechnungen müssen dem europäischen Standard EN 16931 entsprechen, z. B. in den Formaten ZUGFeRD/Factur-X oder XRechnung.
+- XRechnung ist ein deutsches Profil und ein Teilmengenstandard von EN 16931.
+- Jede Rechnung enthält strukturierte Positionen (Material, Anfahrt, Arbeitszeit) mit Preisen und Steuersätzen.
+
 ---
 
 ## Beispiel-Ablauf
@@ -66,6 +71,30 @@ Entwicklung eines modularen Sprachassistenzsystems, das Telefongespräche mit Ha
     "description": "Badezimmer renoviert",
     "materialIncluded": true
   },
+  "items": [
+    {
+      "description": "Fliesen",
+      "category": "material",
+      "quantity": 20,
+      "unit": "m²",
+      "unit_price": 50
+    },
+    {
+      "description": "Anfahrt",
+      "category": "travel",
+      "quantity": 30,
+      "unit": "km",
+      "unit_price": 0.5
+    },
+    {
+      "description": "Arbeitszeit Meister",
+      "category": "labor",
+      "quantity": 10,
+      "unit": "h",
+      "unit_price": 70,
+      "worker_role": "Meister"
+    }
+  ],
   "amount": {
     "total": 3500,
     "currency": "EUR"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,7 +15,13 @@ def test_default_billing_adapter(monkeypatch):
     """Uses default adapter when none specified"""
     monkeypatch.setattr(app_settings.settings, "billing_adapter", None)
     importlib.reload(billing_adapter)
-    invoice = InvoiceContext(type="InvoiceContext", customer={"name": "Max"}, service={}, amount={})
+    invoice = InvoiceContext(
+        type="InvoiceContext",
+        customer={"name": "Max"},
+        service={},
+        items=[],
+        amount={},
+    )
     result = billing_adapter.send_to_billing_system(invoice)
     assert result["status"] == "success"
     assert "Max" in result["message"]
@@ -100,7 +106,13 @@ def test_store_interaction_unique_dirs(monkeypatch, tmp_path):
         def utcnow(cls):
             return datetime(2023, 1, 1, 12, 0, 0)
     monkeypatch.setattr(persistence, "datetime", DummyDT)
-    invoice = InvoiceContext(type="InvoiceContext", customer={}, service={}, amount={})
+    invoice = InvoiceContext(
+        type="InvoiceContext",
+        customer={},
+        service={},
+        items=[],
+        amount={},
+    )
     dir1 = persistence.store_interaction(b"a", "t", invoice)
     monkeypatch.setattr(DummyDT, "utcnow", classmethod(lambda cls: datetime(2023, 1, 1, 12, 0, 1)))
     dir2 = persistence.store_interaction(b"b", "t", invoice)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -79,6 +79,16 @@ def test_end_to_end(monkeypatch, tmp_data_dir):
         "type": "InvoiceContext",
         "customer": {"name": "Anna"},
         "service": {"description": "paint", "materialIncluded": True},
+        "items": [
+            {
+                "description": "Arbeitszeit Geselle",
+                "category": "labor",
+                "quantity": 1,
+                "unit": "h",
+                "unit_price": 50.0,
+                "worker_role": "Geselle",
+            }
+        ],
         "amount": {"total": 50.0, "currency": "EUR"},
     })
     monkeypatch.setattr(llm_agent.settings, "llm_provider", "openai")
@@ -92,4 +102,5 @@ def test_end_to_end(monkeypatch, tmp_data_dir):
     assert response.status_code == 200
     data = response.json()
     assert data["invoice"]["customer"]["name"] == "Anna"
+    assert data["invoice"]["items"][0]["worker_role"] == "Geselle"
     assert Path(data["log_dir"]).exists()


### PR DESCRIPTION
## Summary
- Add `InvoiceItem` model and extend `InvoiceContext` with item list, invoice number and issue date
- Validate presence of line items and update documentation for EN 16931 e‑invoice formats (XRechnung/ZUGFeRD)
- Adapt tests and examples for itemized invoices with different labor rates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b6428b398832b840e73b6005781e1