### PR TITLE
Add coverage reporting with Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -17,6 +19,17 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest
-      - name: Run tests
+      - name: Run tests with coverage
         run: pytest
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.xml
+      - name: Upload coverage to Codecov
+        if: ${{ env.CODECOV_TOKEN != '' }}
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.xml
+          token: ${{ env.CODECOV_TOKEN }}
+          fail_ci_if_error: true

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ __pycache__/
 recordings/
 data/
 .pytest_cache/
+.coverage
+coverage.xml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Sprachassistent für Handwerker
 
+[![codecov](https://codecov.io/gh/OWNER/handwerker-app/branch/main/graph/badge.svg)](https://codecov.io/gh/OWNER/handwerker-app)
+
 Ein FastAPI-basiertes Backend, das Sprache in strukturierte Rechnungsdaten umwandelt und diese an ein Rechnungssystem weiterreicht.
 
 ## Inhaltsverzeichnis

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -vv
+addopts = -vv --cov=app --cov-report=xml
 log_cli = true
 log_cli_level = INFO
 log_cli_format = %(levelname)s:%(message)s

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ twilio
 gtts
 requests
 pytest
+pytest-cov
 elevenlabs
 openai-whisper
 numpy


### PR DESCRIPTION
## Summary
- add coverage reporting to CI workflow and upload to Codecov
- include pytest-cov for coverage generation and ignore coverage artifacts
- document coverage with Codecov badge in README
- upload coverage to Codecov only when a token is configured

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b650c6170832ba09177b1ce22ccdd