### PR TITLE
Add AWS Lambda deployment pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install aws-sam-cli bandit
+      - name: Run tests
+        run: pytest
+      - name: Run Bandit security scan
+        run: bandit -r app
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Build SAM application
+        run: sam build
+      - name: Deploy SAM application
+        run: sam deploy --no-confirm-changeset --stack-name handwerker-app --capabilities CAPABILITY_IAM

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ inklusive unterschiedlicher Stundensätze für Gesellen und Meister.
 - [MacBook Pro: Lokale Ausführung mit Ollama](#macbook-pro-lokale-ausführung-mit-ollama)
 - [Tests ausführen](#tests-ausführen)
 - [Code Coverage in GitHub anzeigen](#code-coverage-in-github-anzeigen)
+- [Deployment auf AWS Lambda](#deployment-auf-aws-lambda)
 - [Deployment auf Render](#deployment-auf-render)
 - [iPhone: Lokaler Test mit Pyto (experimentell)](#iphone-lokaler-test-mit-pyto-experimentell)
 - [Fehlerbehebung](#fehlerbehebung)
@@ -160,6 +161,21 @@ Um die Testabdeckung direkt auf GitHub nachvollziehen zu können, nutzt dieses P
 5. Nach erfolgreichem Upload zeigt Codecov in Pull Requests einen Statuscheck bzw. Kommentar an, und das Badge im README wird aktualisiert. Ersetze dafür in der Badge-URL den Platzhalter `OWNER` durch deinen GitHub-Benutzernamen oder die Organisation.
 
 Über das Codecov-Dashboard lassen sich bei Bedarf weitere Einstellungen wie Mindestabdeckung oder PR-Kommentare konfigurieren.
+
+## Deployment auf AWS Lambda
+
+Für einen serverlosen Betrieb kann die Anwendung als AWS Lambda Function mit API Gateway bereitgestellt werden.
+
+1. Die Infrastruktur ist in `template.yaml` als AWS SAM Template beschrieben.
+2. `app/lambda_handler.py` nutzt [Mangum](https://github.com/jordaneremieff/mangum), um die FastAPI‑App mit Lambda zu verbinden.
+3. Lokales Deployment erfolgt mit:
+
+   ```bash
+   sam build
+   sam deploy --guided --stack-name handwerker-app
+   ```
+
+4. Für kontinuierliches Deployment über GitHub Actions enthält `.github/workflows/deploy.yml` einen Workflow, der Tests, Bandit‑Security‑Scan sowie Build und Deployment ausführt. Dafür müssen die Secrets `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` und `AWS_REGION` gesetzt sein.
 
 ## Deployment auf Render
 

--- a/app/lambda_handler.py
+++ b/app/lambda_handler.py
@@ -1,0 +1,4 @@
+from mangum import Mangum
+from app.main import app
+
+handler = Mangum(app)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 fastapi
 uvicorn
+mangum
 pydantic
 python-dotenv
 openai

--- a/template.yaml
+++ b/template.yaml
@@ -1,0 +1,31 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Handwerker Sprachassistent auf AWS Lambda
+
+Globals:
+  Function:
+    Timeout: 30
+    MemorySize: 512
+    Runtime: python3.11
+
+Resources:
+  ApiGateway:
+    Type: AWS::Serverless::HttpApi
+
+  HandwerkerFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: .
+      Handler: app.lambda_handler.handler
+      Events:
+        Api:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref ApiGateway
+            Path: /{proxy+}
+            Method: ANY
+      Environment:
+        Variables:
+          # Beispielhafte Umgebungsvariablen; Werte über SAM CLI oder AWS Console setzen
+          LLM_PROVIDER: openai
+          STT_PROVIDER: openai


### PR DESCRIPTION
## Summary
- support running FastAPI app on AWS Lambda via Mangum
- automate deployment using AWS SAM and GitHub Actions
- document serverless setup and add mangum dependency

## Testing
- `pre-commit run --files requirements.txt app/lambda_handler.py template.yaml .github/workflows/deploy.yml README.md`
- `pytest`
- `bandit -r app`

------
https://chatgpt.com/codex/tasks/task_e_689ceee854a4832ba1a5178e6a61215f