### PR TITLE
feat: document remote access to web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,37 @@ export STT_PROVIDER=whisper
 uvicorn app.main:app --reload
 ```
 
+## Weboberfläche im Internet bereitstellen
+
+Standardmäßig lauscht die Anwendung nur auf `localhost` und ist damit nur
+vom eigenen Rechner erreichbar. Soll die Oberfläche aus dem Internet
+zugänglich sein, sind zwei Schritte nötig:
+
+1. **Server auf allen Interfaces starten**
+
+   ```bash
+   uvicorn app.main:app --host 0.0.0.0 --port 8000
+   # im Startskript scripts/run_mac_ollama.sh bereits enthalten
+   ```
+
+2. **Öffentlichen Zugang einrichten**
+
+   - Entweder im Router eine Portweiterleitung auf den lokalen Port 8000
+     konfigurieren und anschließend `http://<deine_IP>:8000/web`
+     aufrufen.
+   - Oder einen Tunnel-Dienst wie [ngrok](https://ngrok.com) verwenden:
+
+     ```bash
+     ngrok http 8000
+     ```
+
+     Die von ngrok ausgegebene URL (`https://<id>.ngrok.io/web`) leitet auf
+     den lokalen Server weiter.
+
+Beachte, dass die Anwendung dadurch öffentlich erreichbar ist. Für
+sensiblere Szenarien sollten Authentifizierung oder ein eingeschränkter
+Zugriff verwendet werden.
+
 ## Tests ausführen
 
 ```bash

--- a/scripts/run_mac_ollama.sh
+++ b/scripts/run_mac_ollama.sh
@@ -42,7 +42,7 @@ ollama serve &
 OLLAMA_PID=$!
 
 # FastAPI-Anwendung starten
-uvicorn app.main:app --reload
+uvicorn app.main:app --reload --host 0.0.0.0
 
 # beim Beenden auch den Ollama-Server stoppen
 kill $OLLAMA_PID


### PR DESCRIPTION
## Summary
- document how to expose the web interface to the internet
- start macOS helper script on all interfaces

## Testing
- `pre-commit run --files README.md scripts/run_mac_ollama.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689da2aeb734832b8f6004f0f1dbc713