### PR TITLE
Make Ollama request timeout configurable

### DIFF
--- a/app/llm_agent.py
+++ b/app/llm_agent.py
@@ -55,7 +55,7 @@ class OllamaProvider(LLMProvider):
             resp = httpx.post(
                 url,
                 json={"model": settings.llm_model, "prompt": prompt, "stream": False},
-                timeout=60,
+                timeout=httpx.Timeout(settings.ollama_timeout, connect=5.0),
             )
         except httpx.RequestError as exc:
             logger.exception("Failed to contact Ollama server at %s", url)
@@ -130,7 +130,7 @@ def check_llm_backend(timeout: float = 5.0) -> bool:
             client.models.list()
         elif settings.llm_provider == "ollama":
             url = f"{settings.ollama_base_url.rstrip('/')}/api/tags"
-            httpx.get(url, timeout=timeout).raise_for_status()
+            httpx.get(url, timeout=httpx.Timeout(timeout, connect=5.0)).raise_for_status()
         else:  # pragma: no cover - unrecognised provider
             return True
     except Exception:

--- a/app/settings.py
+++ b/app/settings.py
@@ -16,6 +16,8 @@ class Settings(BaseSettings):
     llm_provider: str = "openai"
     llm_model: str = "gpt-4o"
     ollama_base_url: str = "http://localhost:11434"
+    # Request timeout for Ollama interactions (seconds)
+    ollama_timeout: float = 60.0
     stt_provider: str = "openai"
     stt_model: str = "whisper-1"
 


### PR DESCRIPTION
## Summary
- Allow configuring Ollama request timeout via new `ollama_timeout` setting
- Use separate connection/read timeouts when contacting Ollama or checking backend health

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689daca46f98832b89be3c1f3db2795b