### PR TITLE
Add invoice defaults and transcript cleanup

### DIFF
--- a/app/pdf.py
+++ b/app/pdf.py
@@ -32,6 +32,8 @@ def generate_invoice_pdf(invoice: InvoiceContext, file_path: Path) -> None:
     c.setSubject("E-Rechnung")
 
     lines = [
+        f"Rechnungsnummer: {invoice.invoice_number or ''}",
+        f"Datum: {invoice.issue_date or ''}",
         f"Kunde: {invoice.customer.get('name', '')}",
         f"Leistung: {invoice.service.get('description', '')}",
         "Positionen:",

--- a/app/persistence.py
+++ b/app/persistence.py
@@ -21,7 +21,7 @@ def store_interaction(audio: bytes, transcript: str, invoice: InvoiceContext) ->
     (session_dir / "audio.wav").write_bytes(audio)
     (session_dir / "transcript.txt").write_text(transcript, encoding="utf-8")
     (session_dir / "invoice.json").write_text(
-        json.dumps(invoice.model_dump(), ensure_ascii=False, indent=2),
+        json.dumps(invoice.model_dump(mode="json"), ensure_ascii=False, indent=2),
         encoding="utf-8",
     )
     generate_invoice_pdf(invoice, session_dir / "invoice.pdf")

--- a/app/pricing.py
+++ b/app/pricing.py
@@ -1,0 +1,58 @@
+"""Hilfsfunktionen zur Bewertung von Rechnungspositionen."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from fastapi import HTTPException
+
+from app.models import InvoiceContext, InvoiceItem
+from app.settings import settings
+
+
+def apply_pricing(invoice: InvoiceContext) -> None:
+    """Ergänzt fehlende Preise und Basisangaben in einer Rechnung.
+
+    - Setzt für bekannte Kategorien Standardpreise aus den Einstellungen.
+    - Berechnet den Gesamtbetrag aus den Positionen.
+    - Vergibt Rechnungsnummer und Datum, falls nicht vorhanden.
+    - Wirft eine ``HTTPException``, wenn für eine Position kein Preis
+      ermittelt werden kann.
+    """
+
+    for item in invoice.items:
+        if not item.unit_price:
+            _apply_item_price(item)
+
+    invoice.amount["total"] = sum(i.total for i in invoice.items)
+
+    if not invoice.invoice_number:
+        invoice.invoice_number = f"INV-{datetime.utcnow():%Y%m%d%H%M%S}"
+    if not invoice.issue_date:
+        invoice.issue_date = date.today()
+
+
+def _apply_item_price(item: InvoiceItem) -> None:
+    """Weist einer Rechnungsposition einen Standardpreis zu."""
+    if item.category == "travel":
+        item.unit_price = settings.travel_rate_per_km
+    elif item.category == "labor":
+        role = (item.worker_role or "").lower()
+        if "meister" in role:
+            item.unit_price = settings.labor_rate_meister
+        elif "gesell" in role:
+            item.unit_price = settings.labor_rate_geselle
+        else:
+            item.unit_price = settings.labor_rate_default
+    elif item.category == "material":
+        if settings.material_rate_default is not None:
+            item.unit_price = settings.material_rate_default
+        else:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Preis für Material '{item.description}' fehlt",
+            )
+    else:  # pragma: no cover - unbekannte Kategorie
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unbekannte Kategorie '{item.category}'",
+        )

--- a/app/settings.py
+++ b/app/settings.py
@@ -26,6 +26,14 @@ class Settings(BaseSettings):
     tts_provider: str = "gtts"
     elevenlabs_api_key: SecretStr | None = None
 
+    # Standardpreise für Positionen, damit Rechnungen sinnvolle Beträge
+    # enthalten, selbst wenn keine expliziten Angaben gemacht werden.
+    travel_rate_per_km: float = 1.0
+    labor_rate_geselle: float = 50.0
+    labor_rate_meister: float = 70.0
+    labor_rate_default: float = 60.0
+    material_rate_default: float | None = None
+
     # Verhalten beim Start, falls das LLM nicht erreichbar ist
     fail_on_llm_unavailable: bool = False
 

--- a/app/transcriber.py
+++ b/app/transcriber.py
@@ -122,4 +122,16 @@ def _select_provider() -> STTProvider:
 def transcribe_audio(audio_bytes: bytes) -> str:
     """Convenience-Funktion für andere Module."""
     provider = _select_provider()
-    return provider.transcribe(audio_bytes)
+    raw = provider.transcribe(audio_bytes)
+    return _normalize_transcript(raw)
+
+
+def _normalize_transcript(text: str) -> str:
+    """Korrigiert häufige Erkennungsfehler im Transkript."""
+    replacements = {
+        "Geselden": "Gesellen",
+        "Geseldenstunde": "Gesellenstunde",
+    }
+    for wrong, correct in replacements.items():
+        text = text.replace(wrong, correct)
+    return text

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -88,6 +88,15 @@ def test_transcribe_audio(monkeypatch):
     assert result == "hallo"
 
 
+def test_transcribe_audio_normalized(monkeypatch):
+    """Normalisiert häufige Erkennungsfehler im Transkript."""
+    monkeypatch.setattr(transcriber.settings, "stt_provider", "openai")
+    monkeypatch.setattr(transcriber.settings, "stt_model", "whisper-1")
+    monkeypatch.setattr(transcriber, "OpenAI", lambda: DummyOpenAI("eine Geseldenstunde"))
+    result = transcriber.transcribe_audio(b"audio")
+    assert result == "eine Gesellenstunde"
+
+
 def test_transcribe_audio_command(monkeypatch):
     """Transcribes audio using a command line STT backend"""
     monkeypatch.setattr(transcriber.settings, "stt_provider", "command")

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -1,0 +1,61 @@
+import pytest
+from datetime import date
+
+from fastapi import HTTPException
+
+from app.models import InvoiceContext, InvoiceItem
+from app.pricing import apply_pricing
+from app.settings import settings
+
+
+def _base_invoice(items):
+    return InvoiceContext(
+        type="InvoiceContext",
+        customer={"name": "Max"},
+        service={"description": "Arbeit"},
+        items=items,
+        amount={"total": 0, "currency": "EUR"},
+    )
+
+
+def test_apply_pricing_defaults():
+    invoice = _base_invoice([
+        InvoiceItem(
+            description="Fahrt",
+            category="travel",
+            quantity=10,
+            unit="km",
+            unit_price=0,
+        ),
+        InvoiceItem(
+            description="Arbeit",
+            category="labor",
+            quantity=2,
+            unit="h",
+            unit_price=0,
+            worker_role="Geselle",
+        ),
+    ])
+
+    apply_pricing(invoice)
+
+    assert invoice.items[0].unit_price == settings.travel_rate_per_km
+    assert invoice.items[1].unit_price == settings.labor_rate_geselle
+    assert invoice.amount["total"] == invoice.items[0].total + invoice.items[1].total
+    assert invoice.invoice_number is not None
+    assert invoice.issue_date == date.today()
+
+
+def test_apply_pricing_material_missing():
+    invoice = _base_invoice([
+        InvoiceItem(
+            description="Material",
+            category="material",
+            quantity=1,
+            unit="stk",
+            unit_price=0,
+        )
+    ])
+
+    with pytest.raises(HTTPException):
+        apply_pricing(invoice)


### PR DESCRIPTION
## Summary
- normalize common STT mistakes like "Geseldenstunde"
- add configurable default rates for travel and labor
- ensure invoices get defaults, numbering, and PDF metadata
- cover new pricing logic with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689dba2f5eb0832b88a8bd32726e4c8e