### PR TITLE
Handle comments in invoice JSON

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -51,6 +51,14 @@ def parse_invoice_context(invoice_json: str) -> "InvoiceContext":
     match = re.search(r"\{.*\}", cleaned, re.DOTALL)
     if match:
         cleaned = match.group(0)
+
+    # LLM-Ausgaben sind nicht immer gültiges JSON. Häufig enthalten sie
+    # Kommentare oder überflüssige Kommata. Diese versuchen wir zu
+    # entfernen, bevor ``json.loads`` aufgerufen wird. Die Regex für
+    # Zeilenkommentare ignoriert Protokolle wie ``https://``.
+    cleaned = re.sub(r"(?<!:)//.*", "", cleaned)
+    cleaned = re.sub(r"/\*.*?\*/", "", cleaned, flags=re.DOTALL)
+    cleaned = re.sub(r",\s*(?=[}\]])", "", cleaned)
     try:
         data = json.loads(cleaned)
     except json.JSONDecodeError as exc:  # pragma: no cover - defensive

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -25,6 +25,29 @@ def test_parse_invoice_context_missing_items():
     assert invoice.items == []
 
 
+def test_parse_invoice_context_with_comments_and_trailing_commas():
+    raw = """
+    {
+      "type": "InvoiceContext", // Kommentar
+      "customer": { "name": "Hans" },
+      "service": { "description": "Malen" },
+      "items": [
+        {
+          "description": "Holz", // Kommentar
+          "category": "material",
+          "quantity": 1,
+          "unit": "stk",
+          "unit_price": 5, // Kommentar
+        },
+      ],
+      "amount": { "total": 5, "currency": "EUR" },
+    }
+    """
+    invoice = parse_invoice_context(raw)
+    assert invoice.items[0].description == "Holz"
+    assert invoice.amount["total"] == 5
+
+
 def test_missing_invoice_fields():
     invoice = InvoiceContext(type="InvoiceContext", customer={}, service={}, items=[], amount={})
     missing = missing_invoice_fields(invoice)


### PR DESCRIPTION
## Summary
- Strip comments and trailing commas from LLM invoice JSON before parsing
- Test that parsing succeeds despite comments and extra commas

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689df8f423b4832b9b11386f010406de