### PR TITLE
Add interactive voice conversation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ inklusive unterschiedlicher Stundensätze für Gesellen und Meister.
 - [Installation und Start](#installation-und-start)
 - [Telefonie konfigurieren](#telefonie-konfigurieren)
 - [Audioverarbeitung & Weboberfläche](#audioverarbeitung--weboberfläche)
+- [Dialogbasierte Konversation](#dialogbasierte-konversation)
 - [Lokaler LLM (Ollama)](#lokaler-llm-ollama)
 - [MacBook Pro: Lokale Ausführung mit Ollama](#macbook-pro-lokale-ausführung-mit-ollama)
 - [Tests ausführen](#tests-ausführen)
@@ -94,7 +95,15 @@ Die Antwort enthält das erkannte Transkript, die extrahierten Rechnungsdaten so
 
 ### Weboberfläche
 
-Zum schnellen Testen gibt es eine kleine HTML-Oberfläche unter `/web`. Dort kann direkt im Browser eine Aufnahme gestartet und anschließend als WAV-Datei an `/process-audio/` gesendet werden. Das Ergebnis wird nach dem Upload auf der Seite dargestellt.
+Unter `/web` steht eine moderne, dialogbasierte Oberfläche zur Verfügung. Über das Mikrofon-Symbol lassen sich Sprachbeiträge aufzeichnen, die an den Endpunkt `/conversation/` geschickt werden. Der Assistent stellt Rückfragen, spielt sie als Audio ab und zeigt den Chatverlauf an. Sobald alle Angaben vorliegen, wird die Rechnung erzeugt und als PDF eingebettet.
+
+## Dialogbasierte Konversation
+
+Über den Endpunkt `/conversation/` lässt sich ein mehrstufiger Sprachdialog führen.
+Jede gesprochene Eingabe wird transkribiert und ausgewertet. Solange wichtige
+Rechnungsfelder fehlen, stellt der Assistent Rückfragen und liefert die nächste
+Sprachausgabe bereits als Base64-kodiertes MP3 zurück. Ist alles vollständig,
+wird die Rechnung erstellt und eine Abschlussnachricht ausgegeben. Die Weboberfläche unter `/web` nutzt diesen Ablauf und bietet eine komfortable Audio-Konversation direkt im Browser.
 
 ## Lokaler LLM (Ollama)
 

--- a/app/conversation.py
+++ b/app/conversation.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import base64
+from typing import Dict
+
+from fastapi import APIRouter, UploadFile, File, Form
+
+from app.transcriber import transcribe_audio
+from app.llm_agent import extract_invoice_context
+from app.models import parse_invoice_context, missing_invoice_fields
+from app.tts import text_to_speech
+from app.billing_adapter import send_to_billing_system
+from app.persistence import store_interaction
+
+router = APIRouter()
+
+# Zwischenspeicher für laufende Konversationen.
+SESSIONS: Dict[str, str] = {}
+
+
+@router.post("/conversation/")
+async def voice_conversation(
+    session_id: str = Form(...),
+    file: UploadFile = File(...),
+):
+    """Führt eine dialogorientierte Aufnahme durch."""
+    audio_bytes = await file.read()
+
+    # Neues Transkript zur Session hinzufügen.
+    transcript_part = transcribe_audio(audio_bytes)
+    full_transcript = (SESSIONS.get(session_id, "") + " " + transcript_part).strip()
+    SESSIONS[session_id] = full_transcript
+
+    # Rechnungsdaten aus dem bisherigen Gespräch extrahieren.
+    invoice_json = extract_invoice_context(full_transcript)
+    try:
+        invoice = parse_invoice_context(invoice_json)
+    except ValueError:
+        missing = [
+            "Bitte nennen Sie den Kundennamen, die Dienstleistung und den Betrag."
+        ]
+        invoice = None  # type: ignore
+    else:
+        missing = missing_invoice_fields(invoice)
+
+    if missing:
+        question_map = {
+            "customer.name": "Wie heißt der Kunde?",
+            "service.description": "Welche Dienstleistung wurde erbracht?",
+            "amount.total": "Wie hoch ist der Gesamtbetrag?",
+        }
+        question = question_map.get(missing[0], missing[0])
+        audio_b64 = base64.b64encode(text_to_speech(question)).decode("ascii")
+        return {
+            "done": False,
+            "question": question,
+            "audio": audio_b64,
+            "transcript": full_transcript,
+        }
+
+    # Alle Angaben vollständig – Rechnung erzeugen und Session aufräumen.
+    send_to_billing_system(invoice)
+    log_dir = store_interaction(audio_bytes, full_transcript, invoice)
+    SESSIONS.pop(session_id, None)
+    message = (
+        "Die Rechnung für "
+        f"{invoice.customer['name']} über {invoice.amount['total']} Euro "
+        "wurde erstellt."
+    )
+    audio_b64 = base64.b64encode(text_to_speech(message)).decode("ascii")
+    return {
+        "done": True,
+        "message": message,
+        "audio": audio_b64,
+        "invoice": invoice.model_dump(mode="json"),
+        "log_dir": log_dir,
+        "transcript": full_transcript,
+    }

--- a/app/main.py
+++ b/app/main.py
@@ -14,6 +14,7 @@ from app.pricing import apply_pricing
 from app.persistence import store_interaction
 from app.settings import settings
 from app.telephony import router as telephony_router
+from app.conversation import router as conversation_router
 from app.transcriber import transcribe_audio
 from app.logging_config import configure_logging
 
@@ -28,6 +29,7 @@ app.mount("/static", StaticFiles(directory="app/static"), name="static")
 # Sitzungsartefakte (z. B. generierte PDFs) unter /data verfügbar machen.
 app.mount("/data", StaticFiles(directory="data"), name="data")
 app.include_router(telephony_router)
+app.include_router(conversation_router)
 
 
 @app.on_event("startup")

--- a/app/static/conversation.js
+++ b/app/static/conversation.js
@@ -1,0 +1,73 @@
+
+document.addEventListener('DOMContentLoaded', () => {
+  const recordBtn = document.getElementById('record');
+  const status = document.getElementById('status');
+  const chat = document.getElementById('chat');
+  const pdfFrame = document.getElementById('pdfViewer');
+
+  const sessionId = crypto.randomUUID();
+  let recorder;
+  let audioStream;
+  let fullTranscript = '';
+
+  function addMessage(text, sender) {
+    const wrapper = document.createElement('div');
+    wrapper.className = sender === 'user' ? 'flex justify-end' : 'flex justify-start';
+    const bubble = document.createElement('div');
+    bubble.className =
+      'px-4 py-2 rounded-lg max-w-xs shadow ' +
+      (sender === 'user' ? 'bg-blue-600 text-white' : 'bg-gray-200');
+    bubble.textContent = text;
+    wrapper.appendChild(bubble);
+    chat.appendChild(wrapper);
+    chat.scrollTop = chat.scrollHeight;
+  }
+
+  recordBtn.addEventListener('click', async () => {
+    if (!recordBtn.classList.contains('recording')) {
+      audioStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const audioContext = new AudioContext();
+      const input = audioContext.createMediaStreamSource(audioStream);
+      recorder = new Recorder(input, { numChannels: 1 });
+      recorder.record();
+      recordBtn.classList.add('recording', 'bg-red-600');
+      status.textContent = 'Aufnahme läuft...';
+    } else {
+      recorder.stop();
+      audioStream.getTracks().forEach((t) => t.stop());
+      recordBtn.classList.remove('recording', 'bg-red-600');
+      status.textContent = 'Verarbeite...';
+      recorder.exportWAV(sendAudio);
+    }
+  });
+
+  async function sendAudio(blob) {
+    const fd = new FormData();
+    fd.append('session_id', sessionId);
+    fd.append('file', blob, 'audio.wav');
+    const resp = await fetch('/conversation/', { method: 'POST', body: fd });
+    const data = await resp.json();
+
+    const userPart = data.transcript.slice(fullTranscript.length).trim();
+    if (userPart) {
+      addMessage(userPart, 'user');
+      fullTranscript = data.transcript;
+    }
+
+    if (data.question) {
+      addMessage(data.question, 'bot');
+    }
+    if (data.message) {
+      addMessage(data.message, 'bot');
+    }
+    if (data.audio) {
+      new Audio(`data:audio/mpeg;base64,${data.audio}`).play();
+    }
+    if (data.done && data.log_dir) {
+      pdfFrame.src = '/' + data.log_dir + '/invoice.pdf';
+      pdfFrame.classList.remove('hidden');
+    }
+    status.textContent = '';
+  }
+});
+

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -1,70 +1,20 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-    <meta charset="UTF-8">
-    <title>Audio Upload</title>
-    <style>
-        body { font-family: Arial, sans-serif; margin: 2em; }
-        button { font-size: 1.2em; margin-right: 1em; }
-        #result { margin-top: 1em; white-space: pre-wrap; }
-    </style>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sprachassistent</title>
+  <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body>
-<h1>Audio aufnehmen</h1>
-<button id="record">Aufnahme starten</button>
-<button id="stop" disabled>Stoppen</button>
-<div id="status"></div>
-<div id="result"></div>
-<iframe id="pdfViewer" style="width:100%;height:600px;margin-top:1em;"></iframe>
-<script src="/static/recorder.js"></script>
-<script>
-let recorder;
-let audioStream;
-const recordButton = document.getElementById('record');
-const stopButton = document.getElementById('stop');
-const statusDiv = document.getElementById('status');
-const resultDiv = document.getElementById('result');
-const pdfFrame = document.getElementById('pdfViewer');
-
-recordButton.onclick = async () => {
-    audioStream = await navigator.mediaDevices.getUserMedia({ audio: true });
-    const audioContext = new AudioContext();
-    const input = audioContext.createMediaStreamSource(audioStream);
-    recorder = new Recorder(input, { numChannels: 1 });
-    recorder.record();
-    recordButton.disabled = true;
-    stopButton.disabled = false;
-    statusDiv.textContent = 'Aufnahme läuft...';
-};
-
-stopButton.onclick = () => {
-    recorder.stop();
-    audioStream.getTracks().forEach(t => t.stop());
-    recorder.exportWAV(blob => {
-        uploadAudio(blob);
-    });
-    recordButton.disabled = false;
-    stopButton.disabled = true;
-    statusDiv.textContent = 'Verarbeite...';
-};
-
-function uploadAudio(blob) {
-    const formData = new FormData();
-    formData.append('file', blob, 'audio.wav');
-    fetch('/process-audio/', {
-        method: 'POST',
-        body: formData
-    }).then(resp => resp.json())
-      .then(data => {
-        statusDiv.textContent = '';
-        resultDiv.textContent = JSON.stringify(data, null, 2);
-        if (data.pdf_url) {
-            pdfFrame.src = data.pdf_url;
-        }
-      }).catch(err => {
-        statusDiv.textContent = 'Fehler: ' + err;
-      });
-}
-</script>
+<body class="h-screen flex flex-col bg-gray-100">
+  <header class="bg-blue-600 text-white text-center py-4 text-2xl font-semibold">Handwerker Sprachassistent</header>
+  <main id="chat" class="flex-1 overflow-y-auto p-4 space-y-4"></main>
+  <div class="p-4 bg-white flex flex-col items-center">
+    <button id="record" class="w-16 h-16 rounded-full bg-blue-600 text-white flex items-center justify-center text-2xl shadow-lg transition-colors">🎤</button>
+    <p id="status" class="mt-2 text-gray-600"></p>
+    <iframe id="pdfViewer" class="w-full h-64 mt-4 hidden"></iframe>
+  </div>
+  <script src="/static/recorder.js"></script>
+  <script src="/static/conversation.js"></script>
 </body>
 </html>

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -1,0 +1,74 @@
+import os
+import sys
+import json
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.main import app  # noqa: E402
+import app.conversation as conversation  # noqa: E402
+
+
+def test_conversation_followup(monkeypatch, tmp_data_dir):
+    """Asks questions until all invoice data is provided."""
+    conversation.SESSIONS.clear()
+
+    transcripts = iter(["", "Hans Malen 100"])
+    monkeypatch.setattr(conversation, "transcribe_audio", lambda b: next(transcripts))
+
+    def fake_extract(text):
+        data = {
+            "type": "InvoiceContext",
+            "customer": {},
+            "service": {},
+            "items": [],
+            "amount": {},
+        }
+        if "Hans" in text:
+            data["customer"] = {"name": "Hans"}
+        if "Malen" in text:
+            data["service"] = {"description": "Malen", "materialIncluded": True}
+            data["items"].append(
+                {
+                    "description": "Arbeitszeit Geselle",
+                    "category": "labor",
+                    "quantity": 1,
+                    "unit": "h",
+                    "unit_price": 40,
+                    "worker_role": "Geselle",
+                }
+            )
+        if "100" in text:
+            data["amount"] = {"total": 100.0, "currency": "EUR"}
+        return json.dumps(data)
+
+    monkeypatch.setattr(conversation, "extract_invoice_context", fake_extract)
+    monkeypatch.setattr(conversation, "send_to_billing_system", lambda i: {"ok": True})
+    monkeypatch.setattr(
+        conversation, "store_interaction", lambda a, t, i: str(tmp_data_dir)
+    )
+    monkeypatch.setattr(conversation, "text_to_speech", lambda t: b"mp3")
+
+    client = TestClient(app)
+    session_id = "abc"
+
+    resp = client.post(
+        "/conversation/",
+        data={"session_id": session_id},
+        files={"file": ("audio.wav", b"data")},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["done"] is False
+    assert "Wie heißt der Kunde" in data["question"]
+
+    resp = client.post(
+        "/conversation/",
+        data={"session_id": session_id},
+        files={"file": ("audio.wav", b"data")},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["done"] is True
+    assert data["invoice"]["customer"]["name"] == "Hans"
+    assert "Rechnung" in data["message"]


### PR DESCRIPTION
## Summary
- add `/conversation/` endpoint enabling multi-turn audio dialogues
- hook conversation router into main FastAPI app
- modernize browser interface with Tailwind-based chat that records audio, plays assistant responses and embeds generated invoices
- document conversational web workflow in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0ac1860b8832bb8440c726ecda58d