### PR TITLE
Skip deploy workflow when AWS credentials are missing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   deploy:
+    if: ${{ secrets.AWS_ACCESS_KEY_ID && secrets.AWS_SECRET_ACCESS_KEY && secrets.AWS_REGION }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- only run deploy job if AWS credentials secrets are defined

## Testing
- `pre-commit run --files .github/workflows/deploy.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0ba206030832b8392d31d19445245