### PR TITLE
feat(ui): add Eunoia conversational hub

### DIFF
--- a/app/static/eunoia.html
+++ b/app/static/eunoia.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Eunoia Conversational Hub</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    #record.recording {
+      animation: pulse 1.5s infinite;
+    }
+    @keyframes pulse {
+      0%, 100% { transform: scale(1); }
+      50% { transform: scale(1.1); }
+    }
+  </style>
+</head>
+<body class="h-screen bg-gradient-to-br from-indigo-600 via-sky-500 to-emerald-500 flex flex-col text-gray-900">
+  <header class="text-white text-center py-6 text-3xl font-bold tracking-wide bg-black/20 backdrop-blur-sm">
+    Eunoia Conversational Hub
+  </header>
+  <main class="flex-1 flex items-center justify-center px-4">
+    <div class="w-full max-w-3xl flex flex-col h-[80vh] bg-white/30 backdrop-blur-xl rounded-xl shadow-2xl overflow-hidden">
+      <div id="chat" class="flex-1 overflow-y-auto p-6 space-y-4"></div>
+      <div class="p-6 bg-white/40 backdrop-blur flex flex-col items-center">
+        <div class="flex gap-4">
+          <button id="record" class="w-20 h-20 rounded-full bg-indigo-600 text-white flex items-center justify-center text-3xl shadow-lg transition duration-300 ease-in-out hover:bg-indigo-500 focus:outline-none focus:ring-4 focus:ring-indigo-300">
+            🎤
+          </button>
+          <button id="upload" class="w-20 h-20 rounded-full bg-emerald-600 text-white flex items-center justify-center text-2xl shadow-lg transition duration-300 ease-in-out hover:bg-emerald-500 focus:outline-none focus:ring-4 focus:ring-emerald-300">
+            ⬆️
+          </button>
+          <input id="fileInput" type="file" accept="audio/*" class="hidden" />
+        </div>
+        <p id="status" class="mt-2 text-gray-700"></p>
+        <div id="fileResult" class="w-full mt-4 text-sm text-gray-800"></div>
+        <iframe id="pdfViewer" class="w-full h-48 mt-4 hidden rounded"></iframe>
+      </div>
+    </div>
+  </main>
+  <script src="/static/recorder.js"></script>
+  <script src="/static/conversation.js"></script>
+  <script src="/static/process-audio.js"></script>
+</body>
+</html>

--- a/app/static/process-audio.js
+++ b/app/static/process-audio.js
@@ -1,0 +1,31 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const uploadBtn = document.getElementById('upload');
+  const fileInput = document.getElementById('fileInput');
+  const result = document.getElementById('fileResult');
+  const pdfFrame = document.getElementById('pdfViewer');
+
+  uploadBtn.addEventListener('click', () => fileInput.click());
+
+  fileInput.addEventListener('change', async () => {
+    if (!fileInput.files?.length) return;
+    const fd = new FormData();
+    fd.append('file', fileInput.files[0]);
+
+    const resp = await fetch('/process-audio/', { method: 'POST', body: fd });
+    const data = await resp.json();
+
+    result.innerHTML = `
+      <p class="font-semibold">Transkript:</p>
+      <p class="mb-2">${data.transcript}</p>
+      <p class="font-semibold">Rechnungsdaten:</p>
+      <pre class="bg-gray-100 p-2 rounded text-sm">${JSON.stringify(data.invoice, null, 2)}</pre>
+    `;
+
+    if (data.pdf_url) {
+      pdfFrame.src = data.pdf_url;
+      pdfFrame.classList.remove('hidden');
+    }
+
+    fileInput.value = '';
+  });
+});


### PR DESCRIPTION
## Summary
- introduce `Eunoia Conversational Hub` HTML interface with glassmorphic gradient layout
- keep existing audio conversation workflow with an animated record button and PDF preview
- extend demo UI with audio file upload to leverage single-shot `/process-audio/` endpoint and display transcript & invoice data

## Testing
- `pre-commit run --files app/static/eunoia.html app/static/process-audio.js`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0ba80b54c832b953bfba33f03b164