### PR TITLE
Preserve invoice state across parse errors

### DIFF
--- a/app/conversation.py
+++ b/app/conversation.py
@@ -26,6 +26,8 @@ router = APIRouter()
 
 # Zwischenspeicher für laufende Konversationen
 SESSIONS: Dict[str, str] = {}
+# Zuletzt erfolgreicher Rechnungszustand pro Session
+INVOICE_STATE: Dict[str, InvoiceContext] = {}
 
 # Pfad zur Konfigurationsdatei
 ENV_PATH = Path(".env")
@@ -98,11 +100,17 @@ async def voice_conversation(
 
     # Rechnungsdaten aus dem bisherigen Gespräch extrahieren.
     invoice_json = extract_invoice_context(full_transcript)
+    parse_error = False
     try:
         invoice = parse_invoice_context(invoice_json)
+        INVOICE_STATE[session_id] = invoice
     except ValueError:
-        invoice = InvoiceContext(
-            type="InvoiceContext", customer={}, service={}, items=[], amount={}
+        parse_error = True
+        invoice = INVOICE_STATE.get(
+            session_id,
+            InvoiceContext(
+                type="InvoiceContext", customer={}, service={}, items=[], amount={}
+            ),
         )
 
     # Fehlende Felder vor dem Ausfüllen ermitteln.
@@ -123,6 +131,20 @@ async def voice_conversation(
     log_dir = store_interaction(audio_bytes, full_transcript, invoice)
     pdf_path = str(Path(log_dir) / "invoice.pdf")
     pdf_url = "/" + pdf_path.replace("\\", "/")
+
+    if parse_error and session_id in INVOICE_STATE:
+        question = "Wie viele Stunden wurden abgerechnet?"
+        audio_b64 = base64.b64encode(text_to_speech(question)).decode("ascii")
+        return {
+            "done": False,
+            "question": question,
+            "audio": audio_b64,
+            "transcript": full_transcript,
+            "invoice": invoice.model_dump(mode="json"),
+            "log_dir": log_dir,
+            "pdf_path": pdf_path,
+            "pdf_url": pdf_url,
+        }
 
     if missing:
         question_map = {

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -104,6 +104,75 @@ def test_conversation_parse_error(monkeypatch, tmp_data_dir):
     assert any(item["category"] == "labor" for item in data["invoice"]["items"])
 
 
+def test_conversation_parse_error_keeps_state(monkeypatch, tmp_data_dir):
+    """Parse-Fehler sollen vorhandene Rechnungsdaten nicht verwerfen."""
+    conversation.SESSIONS.clear()
+    conversation.INVOICE_STATE.clear()
+
+    transcripts = iter(["Hans Malen", "Nur eine Stunde"])
+    monkeypatch.setattr(conversation, "transcribe_audio", lambda b: next(transcripts))
+
+    def fake_extract(text):
+        if "Nur eine Stunde" in text:
+            return "Nur eine Stunde"
+        return json.dumps(
+            {
+                "type": "InvoiceContext",
+                "customer": {"name": "Hans"},
+                "service": {
+                    "description": "Malen",
+                    "materialIncluded": True,
+                },
+                "items": [
+                    {
+                        "description": "Arbeitszeit Geselle",
+                        "category": "labor",
+                        "quantity": 2,
+                        "unit": "h",
+                        "unit_price": 40,
+                        "worker_role": "Geselle",
+                    }
+                ],
+                "amount": {"total": 95.2, "currency": "EUR"},
+            }
+        )
+
+    monkeypatch.setattr(conversation, "extract_invoice_context", fake_extract)
+    monkeypatch.setattr(conversation, "send_to_billing_system", lambda i: {"ok": True})
+    monkeypatch.setattr(
+        conversation, "store_interaction", lambda a, t, i: str(tmp_data_dir)
+    )
+    monkeypatch.setattr(conversation, "text_to_speech", lambda t: b"mp3")
+
+    client = TestClient(app)
+    session_id = "parsekeep"
+
+    resp = client.post(
+        "/conversation/",
+        data={"session_id": session_id},
+        files={"file": ("audio.wav", b"data")},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["done"] is True
+    assert data["invoice"]["customer"]["name"] == "Hans"
+    assert data["invoice"]["service"]["description"] == "Malen"
+    assert session_id in conversation.INVOICE_STATE
+
+    resp = client.post(
+        "/conversation/",
+        data={"session_id": session_id},
+        files={"file": ("audio.wav", b"data")},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["done"] is False
+    invoice = data["invoice"]
+    assert invoice["customer"]["name"] == "Hans"
+    assert invoice["service"]["description"] == "Malen"
+    assert "stund" in data["question"].lower()
+
+
 def test_conversation_store_company_name(monkeypatch, tmp_path):
     """Recognizes command to store company name in .env."""
     conversation.SESSIONS.clear()


### PR DESCRIPTION
## Summary
- maintain last valid invoice per session in new `INVOICE_STATE` store
- handle parse errors by reusing previous invoice and prompting to correct hours
- add regression test ensuring state persists after invalid response

## Testing
- `pytest tests/test_conversation.py::test_conversation_parse_error_keeps_state -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a35a815f70832b88a7270093fd84b3