### PR TITLE
Recompute missing fields after defaults

### DIFF
--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -57,15 +57,13 @@ def test_conversation_provisional_invoice(monkeypatch, tmp_data_dir):
     )
     assert resp.status_code == 200
     data = resp.json()
-    assert data["done"] is False
+    assert data["done"] is True
     invoice = data["invoice"]
     assert invoice["customer"]["name"] == "Unbekannter Kunde"
     assert any(item["category"] == "labor" for item in invoice["items"])
     assert invoice["amount"]["total"] > 300
     assert "pdf_url" in data
-    assert "Welche Positionen" in data["question"]
-    assert "Wie heißt der Kunde" in data["question"]
-    assert "Gesamtbetrag" not in data["question"]
+    assert "message" in data
 
     resp = client.post(
         "/conversation/",
@@ -322,5 +320,5 @@ def test_conversation_keeps_context_on_correction(monkeypatch, tmp_data_dir):
     assert data["done"] is False
     assert data["invoice"]["customer"]["name"] == "Huber"
     assert data["invoice"]["service"]["description"] == "Fenster"
-    assert "Welche Positionen" in data["question"]
+    assert "Wie viele Stunden" in data["question"]
     assert "Wie heißt der Kunde" not in data["question"]


### PR DESCRIPTION
## Summary
- ensure invoice placeholders, labor estimation, and pricing are applied before checking for missing fields
- persist updated invoice state after filling placeholders
- adjust conversation tests for new flow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4377c016c832ba0f7774771b4211e