### PR TITLE
Filter empty invoice items

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -69,6 +69,11 @@ def parse_invoice_context(invoice_json: str) -> "InvoiceContext":
     except ValidationError as exc:  # pragma: no cover - defensive
         raise ValueError("invalid invoice context") from exc
 
+    # Platzhalter ohne Beschreibung oder Menge entfernen
+    invoice.items = [
+        item for item in invoice.items if item.description.strip() and item.quantity > 0
+    ]
+
     # Nach dem Parsen prüfen wir jede Rechnungsposition auf Schlüsselwörter,
     # die auf Reisekosten hindeuten. Zusätzlich normalisieren wir Positionen,
     # die fälschlicherweise als Währungsmenge interpretiert wurden.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -34,6 +34,34 @@ def test_parse_invoice_context_missing_items():
     assert invoice.items == []
 
 
+def test_parse_invoice_context_filters_empty_items():
+    data = {
+        "type": "InvoiceContext",
+        "customer": {},
+        "service": {},
+        "items": [
+            {
+                "description": "",
+                "category": "travel",
+                "quantity": 0,
+                "unit": "km",
+                "unit_price": 1,
+            },
+            {
+                "description": "Fenster-Material",
+                "category": "material",
+                "quantity": 1.0,
+                "unit": "Stück",
+                "unit_price": 100.0,
+            },
+        ],
+        "amount": {},
+    }
+    invoice = parse_invoice_context(json.dumps(data))
+    assert len(invoice.items) == 1
+    assert invoice.items[0].description == "Fenster-Material"
+
+
 def test_parse_invoice_context_with_comments_and_trailing_commas():
     raw = """
     {


### PR DESCRIPTION
## Summary
- drop invoice items without description or quantity
- test ignoring empty invoice placeholders

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4517b63a8832b9857c7e4291f8cd9