### PR TITLE
fix: include material costs even when quantity is zero

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -108,6 +108,30 @@ def test_parse_invoice_context_currency_unit_total():
     assert item.unit == "EUR"
 
 
+def test_parse_invoice_context_keeps_zero_quantity_with_price():
+    data = {
+        "type": "InvoiceContext",
+        "customer": {},
+        "service": {},
+        "items": [
+            {
+                "description": "Fenster-Material",
+                "category": "material",
+                "quantity": 0.0,
+                "unit": "EUR",
+                "unit_price": 300.0,
+            }
+        ],
+        "amount": {},
+    }
+    invoice = parse_invoice_context(json.dumps(data))
+    assert len(invoice.items) == 1
+    item = invoice.items[0]
+    assert item.quantity == 1.0
+    assert item.unit_price == 300.0
+    assert item.unit == "EUR"
+
+
 @pytest.mark.parametrize(
     "description",
     ["Anfahrt zur Baustelle", "Fahrtkosten zur Baustelle", "Kilometerpauschale"],


### PR DESCRIPTION
## Summary
- keep invoice items with zero quantity if a price is provided
- test parsing of material position supplied as total amount

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a48468a7b4832bb99f25b2cf7862e5