### PR TITLE
Handle labor items in invoice parsing and adjust fallback hours

### DIFF
--- a/app/service_estimations.py
+++ b/app/service_estimations.py
@@ -7,9 +7,11 @@ from app.service_templates import SERVICE_TEMPLATES
 def estimate_labor_item(service_description: str) -> InvoiceItem:
     """Erzeugt eine Standard-Arbeitsposition basierend auf der Dienstleistung."""
     desc = (service_description or "").lower()
-    hours = 8.0
+    hours = 1.0
     if "malen" in desc or "streichen" in desc:
         hours = 4.0
+    elif "fenster" in desc:
+        hours = 5.0
     elif "dusche" in desc:
         hours = 8.0
     return InvoiceItem(

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -61,7 +61,7 @@ def test_conversation_provisional_invoice(monkeypatch, tmp_data_dir):
     invoice = data["invoice"]
     assert invoice["customer"]["name"] == "Unbekannter Kunde"
     assert any(item["category"] == "labor" for item in invoice["items"])
-    assert invoice["amount"]["total"] > 300
+    assert invoice["amount"]["total"] > 50
     assert "pdf_url" in data
     assert "message" in data
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -156,6 +156,26 @@ def test_parse_invoice_context_corrects_travel_category(description: str):
     assert invoice.items[0].category == "travel"
 
 
+def test_parse_invoice_context_corrects_labor_category():
+    data = {
+        "type": "InvoiceContext",
+        "customer": {},
+        "service": {},
+        "items": [
+            {
+                "description": "1 Handwerkerstunde",
+                "category": "service",
+                "quantity": 1,
+                "unit": "h",
+                "unit_price": 40,
+            }
+        ],
+        "amount": {},
+    }
+    invoice = parse_invoice_context(json.dumps(data))
+    assert invoice.items[0].category == "labor"
+
+
 def test_missing_invoice_fields():
     invoice = InvoiceContext(
         type="InvoiceContext", customer={}, service={}, items=[], amount={}

--- a/tests/test_service_estimations.py
+++ b/tests/test_service_estimations.py
@@ -1,0 +1,11 @@
+from app.service_estimations import estimate_labor_item
+
+
+def test_estimate_labor_item_default_hours():
+    item = estimate_labor_item("unbekannte arbeit")
+    assert item.quantity == 1.0
+
+
+def test_estimate_labor_item_fenster_hours():
+    item = estimate_labor_item("Fenster einbauen")
+    assert item.quantity == 5.0


### PR DESCRIPTION
## Summary
- detect labor items based on units and keywords before validation
- use smarter labor hour estimation with 1h default and fenster-specific 5h
- add tests for labor detection and estimation

## Testing
- `pre-commit run --files app/models.py app/service_estimations.py tests/test_models.py tests/test_service_estimations.py tests/test_conversation.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a495353ad0832b817840bf40ad4218