### PR TITLE
Handle placeholder items in invoice merge

### DIFF
--- a/tests/test_conversation_merge.py
+++ b/tests/test_conversation_merge.py
@@ -69,3 +69,72 @@ def test_merge_invoice_preserves_existing_values_and_adds_new_items():
 
     travel_item = next(i for i in merged.items if i.category == "travel")
     assert travel_item.quantity == 15.0
+
+
+def test_merge_removes_labor_placeholder_for_specific_item():
+    existing = _invoice_with_items(
+        [
+            InvoiceItem(
+                description="Arbeitszeit Geselle",
+                category="labor",
+                quantity=1.0,
+                unit="h",
+                unit_price=0.0,
+                worker_role="Geselle",
+            )
+        ]
+    )
+
+    new = _invoice_with_items(
+        [
+            InvoiceItem(
+                description="Fenster einsetzen",
+                category="labor",
+                quantity=5.0,
+                unit="h",
+                unit_price=55.0,
+                worker_role="Geselle",
+            )
+        ]
+    )
+
+    merged = merge_invoice_data(existing, new)
+
+    assert not any(i.description == "Arbeitszeit Geselle" for i in merged.items)
+    labor_items = [i for i in merged.items if i.category == "labor"]
+    assert len(labor_items) == 1
+    assert labor_items[0].description == "Fenster einsetzen"
+    assert labor_items[0].unit_price == 55.0
+
+
+def test_merge_material_placeholders_with_specific_items():
+    existing = _invoice_with_items(
+        [
+            InvoiceItem(
+                description="Materialkosten",
+                category="material",
+                quantity=1.0,
+                unit="Stk",
+                unit_price=0.0,
+            )
+        ]
+    )
+
+    new = _invoice_with_items(
+        [
+            InvoiceItem(
+                description="Fenster",
+                category="material",
+                quantity=1.0,
+                unit="Stk",
+                unit_price=300.0,
+            )
+        ]
+    )
+
+    merged = merge_invoice_data(existing, new)
+
+    assert not any(i.description == "Materialkosten" for i in merged.items)
+    assert any(
+        i.description == "Fenster" and i.unit_price == 300.0 for i in merged.items
+    )


### PR DESCRIPTION
## Summary
- drop placeholder labor items when specific entries arrive
- consolidate generic material entries with specific items
- test invoice merge placeholder handling

## Testing
- `pre-commit run --files app/conversation.py tests/test_conversation_merge.py`
- `pytest tests/test_conversation_merge.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5d8516974832baaad13059a12f8ca