### PR TITLE
Track role-labelled conversation transcripts

### DIFF
--- a/app/conversation.py
+++ b/app/conversation.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import base64
 import re
 from pathlib import Path
-from typing import Dict
+from typing import Dict, List
 
 from fastapi import APIRouter, File, Form, UploadFile
 
@@ -26,7 +26,7 @@ from app.tts import text_to_speech
 router = APIRouter()
 
 # Zwischenspeicher für laufende Konversationen
-SESSIONS: Dict[str, str] = {}
+SESSIONS: Dict[str, List[Dict[str, str]]] = {}
 # Zuletzt erfolgreicher Rechnungszustand pro Session
 INVOICE_STATE: Dict[str, InvoiceContext] = {}
 
@@ -143,12 +143,17 @@ def _handle_conversation(
             "done": False,
             "message": message,
             "audio": audio_b64,
-            "transcript": SESSIONS.get(session_id, ""),
+            "transcript": " ".join(
+                m["content"] for m in SESSIONS.get(session_id, [])
+            ),
         }
 
     # Neues Transkript zur Session hinzufügen.
-    full_transcript = (SESSIONS.get(session_id, "") + " " + transcript_part).strip()
-    SESSIONS[session_id] = full_transcript
+    session_msgs = SESSIONS.setdefault(session_id, [])
+    session_msgs.append({"role": "user", "content": transcript_part})
+    full_transcript = " ".join(
+        m["content"] for m in session_msgs if m["role"] == "user"
+    )
 
     # Rechnungsdaten aus dem bisherigen Gespräch extrahieren.
     had_state = session_id in INVOICE_STATE
@@ -202,15 +207,15 @@ def _handle_conversation(
     if set(missing).issubset({"customer.name", "service.description"}):
         missing = []
 
-    log_dir = store_interaction(audio_bytes, full_transcript, invoice)
-    pdf_path = str(Path(log_dir) / "invoice.pdf")
-    pdf_url = "/" + pdf_path.replace("\\", "/")
-
     if parse_error and had_state:
         if "stund" in invoice_json.lower():
             question = "Wie viele Stunden wurden abgerechnet?"
         else:
             question = "Welche Positionen wurden abgerechnet?"
+        session_msgs.append({"role": "assistant", "content": question})
+        log_dir = store_interaction(audio_bytes, session_msgs, invoice)
+        pdf_path = str(Path(log_dir) / "invoice.pdf")
+        pdf_url = "/" + pdf_path.replace("\\", "/")
         audio_b64 = base64.b64encode(text_to_speech(question)).decode("ascii")
         return {
             "done": False,
@@ -232,6 +237,10 @@ def _handle_conversation(
         }
         question_lines = [question_map.get(f, f) for f in missing]
         question = "\n".join(question_lines)
+        session_msgs.append({"role": "assistant", "content": question})
+        log_dir = store_interaction(audio_bytes, session_msgs, invoice)
+        pdf_path = str(Path(log_dir) / "invoice.pdf")
+        pdf_url = "/" + pdf_path.replace("\\", "/")
         audio_b64 = base64.b64encode(text_to_speech(question)).decode("ascii")
         return {
             "done": False,
@@ -252,6 +261,10 @@ def _handle_conversation(
     )
     if placeholder_notice:
         message = "Hinweis: Platzhalter verwendet. " + message
+    session_msgs.append({"role": "assistant", "content": message})
+    log_dir = store_interaction(audio_bytes, session_msgs, invoice)
+    pdf_path = str(Path(log_dir) / "invoice.pdf")
+    pdf_url = "/" + pdf_path.replace("\\", "/")
     audio_b64 = base64.b64encode(text_to_speech(message)).decode("ascii")
     return {
         "done": True,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -264,6 +264,7 @@ def test_store_interaction(tmp_data_dir):
     p = Path(session_dir)
     assert (p / "audio.wav").exists()
     assert (p / "transcript.txt").exists()
+    assert (p / "transcript.json").exists()
     assert (p / "invoice.json").exists()
     assert (p / "invoice.pdf").exists()
 


### PR DESCRIPTION
## Summary
- Track user and assistant messages in sessions with role labels
- Persist full dialogue transcripts in `store_interaction`
- Test that transcript.json is created when storing interactions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5d84c8f80832bac6fa0277c8d0dc4