### PR TITLE
Fix pricing tests syntax

### DIFF
--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -111,7 +111,7 @@ def test_apply_pricing_material_placeholder_uses_defaults():
             quantity=0,
             unit="stk",
             unit_price=0,
-        )
+        ),
     ])
 
     apply_pricing(invoice)


### PR DESCRIPTION
## Summary
- Close InvoiceItem parentheses in pricing tests

## Testing
- `python -m py_compile tests/test_pricing.py`
- `pytest tests/test_pricing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5e4739b08832bb8be10fff8f26591