### PR TITLE
Ensure invoice includes customer address

### DIFF
--- a/app/conversation.py
+++ b/app/conversation.py
@@ -149,6 +149,8 @@ def merge_invoice_data(existing: InvoiceContext, new: InvoiceContext) -> Invoice
         "Unbekannter Kunde",
     ) and new.customer.get("name"):
         merged.customer["name"] = new.customer["name"]
+    if not merged.customer.get("address") and new.customer.get("address"):
+        merged.customer["address"] = new.customer["address"]
     if merged.service.get("description") in (
         None,
         "",

--- a/app/llm_agent.py
+++ b/app/llm_agent.py
@@ -105,7 +105,7 @@ def _build_prompt(transcript: str) -> str:
         "eine strukturierte JSON-Rechnung gemäß folgendem Schema:\n\n"
         "{\n"
         '  "type": "InvoiceContext",\n'
-        '  "customer": { "name": str },\n'
+        '  "customer": { "name": str, "address": str },\n'
         '  "service": { "description": str, "materialIncluded": bool },\n'
         '  "items": [\n'
         '    { "description": str, "category": '

--- a/tests/test_conversation_merge.py
+++ b/tests/test_conversation_merge.py
@@ -138,3 +138,22 @@ def test_merge_material_placeholders_with_specific_items():
     assert any(
         i.description == "Fenster" and i.unit_price == 300.0 for i in merged.items
     )
+
+
+def test_merge_adds_customer_address_when_missing():
+    existing = InvoiceContext(
+        type="InvoiceContext",
+        customer={"name": "Kunde"},
+        service={"description": "Fenster einsetzen"},
+        items=[],
+        amount={},
+    )
+    new = InvoiceContext(
+        type="InvoiceContext",
+        customer={"name": "Kunde", "address": "Rathausstr. 11"},
+        service={"description": "Fenster einsetzen"},
+        items=[],
+        amount={},
+    )
+    merged = merge_invoice_data(existing, new)
+    assert merged.customer.get("address") == "Rathausstr. 11"

--- a/tests/test_llm_agent_prompt.py
+++ b/tests/test_llm_agent_prompt.py
@@ -10,3 +10,8 @@ def test_build_prompt_preserves_quotes():
     # Ensure there are no extraneous surrounding quotes around transcript
     # preceding and following context should match expected format
     assert re.search(r"Text:\nEr sagte \"Hallo\" und \"Tschüss\"\n", prompt)
+
+
+def test_build_prompt_requests_address_field():
+    prompt = _build_prompt("Test")
+    assert '"address": str' in prompt


### PR DESCRIPTION
## Summary
- request customer address in LLM extraction
- merge customer address when updating invoice data
- add tests for prompt and merge behaviour

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6dd120888832baa4890f1faa58350