### PR TITLE
Fix test syntax and improve conversation invoice handling

### DIFF
--- a/app/conversation.py
+++ b/app/conversation.py
@@ -164,7 +164,6 @@ def merge_invoice_data(existing: InvoiceContext, new: InvoiceContext) -> Invoice
                 if not existing_item.unit and item.unit:
                     existing_item.unit = item.unit
         else:
-            merged.add_item(item)
             merged.items.append(item)
             item_map[key] = item
 
@@ -236,11 +235,15 @@ def _handle_conversation(
         else:
             message = f"Position {idx} nicht gefunden."
         audio_b64 = base64.b64encode(text_to_speech(message)).decode("ascii")
+        if invoice and not _user_set_customer_name(invoice.customer.get("name"), transcript_part):
+            invoice.customer.pop("name", None)
+            fill_default_fields(invoice)
         return {
             "done": False,
             "message": message,
             "audio": audio_b64,
             "transcript": SESSIONS.get(session_id, ""),
+            "invoice": invoice.model_dump(mode="json") if invoice else None,
         }
 
     # Neues Transkript zur Session hinzufügen.

--- a/tests/test_conversation_merge.py
+++ b/tests/test_conversation_merge.py
@@ -176,4 +176,3 @@ def test_merge_adds_customer_address_when_missing():
     )
     merged = merge_invoice_data(existing, new)
     assert merged.customer.get("address") == "Rathausstr. 11"
-    )

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -102,15 +102,39 @@ def test_material_lookup_and_vat():
     assert invoice.items[0].unit_price == 0.10
     assert invoice.amount["tax"] == pytest.approx(invoice.amount["net"] * settings.vat_rate)
 
+
 def test_repricing_after_item_changes():
-    invoice = _base_invoice([
-        InvoiceItem(
-            description="Arbeit",
-            category="labor",
-            quantity=1,
-            unit="h",
-            unit_price=0,
-            worker_role="Geselle",
+    invoice = _base_invoice(
+        [
+            InvoiceItem(
+                description="Arbeit",
+                category="labor",
+                quantity=1,
+                unit="h",
+                unit_price=0,
+                worker_role="Geselle",
+            )
+        ]
+    )
+
+    apply_pricing(invoice)
+    original_amount = invoice.amount.copy()
+    number = invoice.invoice_number
+    issue_date = invoice.issue_date
+
+    # modify item quantity and reprice
+    invoice.items[0].quantity = 2
+    apply_pricing(invoice)
+
+    assert invoice.amount["net"] == pytest.approx(sum(i.total for i in invoice.items))
+    assert invoice.amount["tax"] == pytest.approx(invoice.amount["net"] * settings.vat_rate)
+    assert invoice.amount["total"] == pytest.approx(
+        invoice.amount["net"] + invoice.amount["tax"]
+    )
+    assert invoice.amount["net"] > original_amount["net"]
+    # invoice metadata should not change on repricing
+    assert invoice.invoice_number == number
+    assert invoice.issue_date == issue_date
 
 def test_apply_pricing_material_placeholder_uses_defaults():
     invoice = _base_invoice(


### PR DESCRIPTION
## Summary
- fix broken test files and add missing repricing test
- prevent duplicate items when merging invoices
- return updated invoice and handle placeholder names on delete command

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6e47953fc832b80a3d1f5a2016dfd