### PR TITLE
Ensure travel distance retained in invoices and test travel item rendering

### DIFF
--- a/tests/test_invoice_template.py
+++ b/tests/test_invoice_template.py
@@ -45,3 +45,23 @@ def test_format_invoice_contains_required_sections(monkeypatch):
     assert "Zahlungsinformationen" in text
     assert "Name/Firma: Test GmbH" in text
     assert "BIC TESTDEFFXXX" in text
+
+
+def test_format_invoice_includes_travel_item(monkeypatch):
+    invoice = _sample_invoice()
+    invoice.add_item(
+        InvoiceItem(
+            description="Anfahrt",
+            category="travel",
+            quantity=15.0,
+            unit="km",
+            unit_price=1.0,
+        )
+    )
+    monkeypatch.setattr(settings, "supplier_name", "Test GmbH")
+    monkeypatch.setattr(settings, "payment_iban", "DE00 0000 0000 0000 0000 00")
+    monkeypatch.setattr(settings, "payment_bic", "TESTDEFFXXX")
+    lines = format_invoice_lines(invoice)
+    travel_lines = [line for line in lines if "Anfahrt" in line]
+    assert travel_lines, "travel item missing"
+    assert "15.0 km" in travel_lines[0]


### PR DESCRIPTION
## Summary
- Parse distance from conversation transcripts and ensure travel item uses it without being overwritten
- Always include an `Anfahrt` invoice item, adding or updating it based on transcript distance
- Add regression test verifying invoice template outputs travel item with km value

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6eb95b7b0832bb04a4810168294de