### PR TITLE
Include explicit material and labor item instructions

### DIFF
--- a/app/llm_agent.py
+++ b/app/llm_agent.py
@@ -103,6 +103,8 @@ def _build_prompt(transcript: str) -> str:
     prompt = (
         "Du bist ein KI-Assistent für Handwerker. Extrahiere aus folgendem Text "
         "eine strukturierte JSON-Rechnung gemäß folgendem Schema:\n\n"
+        "Führe jede im Text erwähnte Material- bzw. Arbeitsposition mit Menge, "
+        "Einheit, Preis und ``worker_role`` auf.\n\n"
         "{\n"
         '  "type": "InvoiceContext",\n'
         '  "customer": { "name": str, "address": str },\n'

--- a/tests/test_llm_agent_prompt.py
+++ b/tests/test_llm_agent_prompt.py
@@ -15,3 +15,9 @@ def test_build_prompt_preserves_quotes():
 def test_build_prompt_requests_address_field():
     prompt = _build_prompt("Test")
     assert '"address": str' in prompt
+
+
+def test_build_prompt_requests_material_and_labor_details():
+    prompt = _build_prompt("Test")
+    assert "Material- bzw. Arbeitsposition" in prompt
+    assert "Menge, Einheit, Preis und ``worker_role``" in prompt


### PR DESCRIPTION
## Summary
- ensure LLM prompt lists every material or labor item with quantity, unit, price, and worker_role
- add tests verifying prompt includes the new material and labor instructions

## Testing
- `pytest tests/test_llm_agent_prompt.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a70fca49b4832b9ec8439e2d3922fb