### PR TITLE
Add invoice item generation with validation and tests

### DIFF
--- a/app/invoice_rules.yaml
+++ b/app/invoice_rules.yaml
@@ -1,0 +1,6 @@
+allowed_units:
+  - h
+  - stk
+price_limits:
+  labor: 100
+  material: 1000

--- a/app/service_estimations.py
+++ b/app/service_estimations.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+from pathlib import Path
+import re
+
+import yaml
+
 from app.models import InvoiceItem
 from app.service_templates import SERVICE_TEMPLATES
 
@@ -24,16 +29,35 @@ def estimate_labor_item(service_description: str) -> InvoiceItem:
     )
 
 
-def estimate_invoice_items(service_description: str) -> list[InvoiceItem]:
-    """Gibt eine Liste von Rechnungspositionen basierend auf Vorlagen zurück.
+def _load_rules() -> dict:
+    """Lädt optionale Validierungsregeln für Rechnungspositionen."""
 
-    Die Beschreibung wird auf bekannte Schlüsselwörter geprüft und bei einem
-    Treffer werden die entsprechenden Vorlagen als ``InvoiceItem``-Objekte
-    zurückgegeben. Wird kein Schlüsselwort gefunden, fällt die Funktion auf
-    eine generische Arbeitsposition zurück.
+    rules_path = Path(__file__).with_name("invoice_rules.yaml")
+    if not rules_path.exists():
+        return {}
+    with rules_path.open("r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh) or {}
+
+
+RULES = _load_rules()
+
+
+def generate_invoice_items(description: str) -> list[InvoiceItem]:
+    """Erzeugt Rechnungspositionen aus freiem Text.
+
+    Aktuell wird eine einfache Regex-basierte Logik verwendet und
+    optionalen Validierungs-vorgaben aus ``invoice_rules.yaml``
+    gefolgt. Bei fehlenden Angaben oder Regelverletzungen wird
+    ``ValueError`` ausgelöst.
     """
 
-    desc = (service_description or "").lower()
+    if not description or not description.strip():
+        raise ValueError("empty description")
+
+    text = description.strip()
+    desc_lower = text.lower()
+
+    # Zuerst bekannte Dienstleistungs-Vorlagen prüfen.
     keyword_map = {
         "dusche": "dusche_einbauen",
         "duschkabine": "dusche_einbauen",
@@ -44,7 +68,52 @@ def estimate_invoice_items(service_description: str) -> list[InvoiceItem]:
         "streichen": "waende_streichen",
     }
     for keyword, template_key in keyword_map.items():
-        if keyword in desc and template_key in SERVICE_TEMPLATES:
+        if keyword in desc_lower and template_key in SERVICE_TEMPLATES:
             return [InvoiceItem(**data) for data in SERVICE_TEMPLATES[template_key]]
 
-    return [estimate_labor_item(service_description)]
+    # Parser für Eingaben wie "2 h Reinigung 30 EUR".
+    pattern = re.compile(
+        r"(?P<qty>\d+(?:\.\d+)?)\s*(?P<unit>\w+)\s+"  # Menge + Einheit
+        r"(?P<desc>.+?)\s+"  # Beschreibung
+        r"(?P<price>\d+(?:\.\d+)?)\s*eur",  # Preis
+        re.IGNORECASE,
+    )
+    match = pattern.search(text)
+    if not match:
+        raise ValueError("parse error")
+
+    quantity = float(match.group("qty"))
+    unit = match.group("unit")
+    item_desc = match.group("desc").strip()
+    unit_price = float(match.group("price"))
+
+    labor_units = {"h", "std", "stunde", "stunden"}
+    category = "labor" if unit.lower() in labor_units else "material"
+
+    # Validierungsregeln anwenden
+    allowed_units = {u.lower() for u in RULES.get("allowed_units", [])}
+    if allowed_units and unit.lower() not in allowed_units:
+        raise ValueError("invalid unit")
+
+    price_limits = RULES.get("price_limits", {})
+    limit = price_limits.get(category)
+    if limit is not None and unit_price > limit:
+        raise ValueError("price exceeds limit")
+
+    item = InvoiceItem(
+        description=item_desc,
+        category=category,
+        quantity=quantity,
+        unit=unit,
+        unit_price=unit_price,
+    )
+    return [item]
+
+
+def estimate_invoice_items(service_description: str) -> list[InvoiceItem]:
+    """Erzeugt Rechnungspositionen oder fällt auf eine generische Position zurück."""
+
+    try:
+        return generate_invoice_items(service_description)
+    except ValueError:
+        return [estimate_labor_item(service_description)]

--- a/tests/test_service_estimations.py
+++ b/tests/test_service_estimations.py
@@ -1,4 +1,10 @@
-from app.service_estimations import estimate_labor_item
+import pytest
+
+from app.service_estimations import (
+    estimate_labor_item,
+    estimate_invoice_items,
+    generate_invoice_items,
+)
 
 
 def test_estimate_labor_item_default_hours():
@@ -9,3 +15,29 @@ def test_estimate_labor_item_default_hours():
 def test_estimate_labor_item_fenster_hours():
     item = estimate_labor_item("Fenster einbauen")
     assert item.quantity == 5.0
+
+
+def test_generate_invoice_items_parses_free_text():
+    items = generate_invoice_items("2 h Reinigung 30 EUR")
+    assert len(items) == 1
+    item = items[0]
+    assert item.description == "Reinigung"
+    assert item.quantity == 2
+    assert item.unit == "h"
+    assert item.unit_price == 30
+
+
+def test_generate_invoice_items_validation_missing_fields():
+    with pytest.raises(ValueError):
+        generate_invoice_items("nur text ohne zahlen")
+
+
+def test_generate_invoice_items_validation_invalid_unit():
+    with pytest.raises(ValueError):
+        generate_invoice_items("2 tage Arbeit 30 EUR")
+
+
+def test_estimate_invoice_items_invalid_unit_fallback():
+    items = estimate_invoice_items("2 tage Arbeit 30 EUR")
+    assert len(items) == 1
+    assert items[0].description == "Arbeitszeit Geselle"


### PR DESCRIPTION
## Summary
- parse free-text descriptions into `InvoiceItem` objects with optional validation rules
- use generator in `estimate_invoice_items` with fallback to a generic labor item
- test invoice item parsing, validation errors, and fallback behavior
- document regex-based parser in `generate_invoice_items`

## Testing
- `ruff check app/service_estimations.py tests/test_service_estimations.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a714eee44c832b9ae1ea7b42930f25