### PR TITLE
Add Neo4j import tooling for knowledge graph

### DIFF
--- a/docs/neo4j_import.md
+++ b/docs/neo4j_import.md
@@ -1,0 +1,89 @@
+# Neo4j Knowledge Graph Import
+
+This guide explains how to reproduce the handwerker-app knowledge graph in a
+local Neo4j instance.  You can either run Neo4j via Docker or use an existing
+installation on your workstation.
+
+## 1. Start Neo4j locally
+
+### Option A – Docker (recommended)
+```bash
+docker run \
+  --rm \
+  --name handwerker-neo4j \
+  -p 7474:7474 -p 7687:7687 \
+  -e NEO4J_AUTH=neo4j/test \
+  neo4j:5.15.0
+```
+This command starts a disposable Neo4j 5.x container with the default password
+`test`.  Wait until the logs show that Bolt is listening on port `7687`.
+
+### Option B – Local installation
+1. Install Neo4j Desktop or the Neo4j Community Edition.
+2. Create (or reuse) a database and ensure that the Bolt connector is exposed on
+   `bolt://localhost:7687`.
+3. Note the username and password for later use.
+
+## 2. Install Python dependencies
+
+The import script uses the official Neo4j Python driver.  Install it into your
+virtual environment:
+
+```bash
+pip install neo4j
+```
+
+If you prefer to keep dependencies isolated, create a dedicated virtual
+environment first.
+
+## 3. Load the knowledge graph
+
+Run the helper script that lives in this repository:
+
+```bash
+python scripts/neo4j/load_knowledge_graph.py \
+  bolt://localhost:7687 \
+  neo4j \
+  test
+```
+
+Replace `neo4j` and `test` with the credentials of your database.  The script
+performs `MERGE` operations, so running it multiple times is idempotent.
+
+## 4. Inspect the graph in Neo4j Browser
+
+1. Open <http://localhost:7474> in your browser.
+2. Log in using the same credentials as above.
+3. Run the following Cypher query to inspect the imported nodes and
+   relationships:
+
+```cypher
+MATCH (n)
+OPTIONAL MATCH (n)-[r]->(m)
+RETURN n, r, m
+```
+
+You can also filter by labels, for example:
+
+```cypher
+MATCH (c:Component)-[r]->(s:Service)
+RETURN c, r, s
+```
+
+## 5. Extend or update the model
+
+The script encodes the nodes and relationships that were identified during the
+architecture analysis.  To adapt it to future findings:
+
+1. Update the `NODES` and `RELATIONSHIPS` lists in
+   [`scripts/neo4j/load_knowledge_graph.py`](../scripts/neo4j/load_knowledge_graph.py).
+2. Re-run the import command.
+3. Use `DETACH DELETE` in Cypher if you need to remove outdated nodes:
+
+```cypher
+MATCH (n {key: "DeprecatedNode"})
+DETACH DELETE n;
+```
+
+With these steps you can reproduce and evolve the project knowledge graph in a
+self-hosted Neo4j database.

--- a/scripts/neo4j/load_knowledge_graph.py
+++ b/scripts/neo4j/load_knowledge_graph.py
@@ -1,0 +1,252 @@
+"""Load the handwerker-app knowledge graph into a Neo4j database.
+
+The script reflects the architecture and business processes described in the
+previous knowledge graph summary.  It uses the official Neo4j Python driver to
+create/merge the nodes and relationships.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List
+
+from neo4j import GraphDatabase
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class Node:
+    """Representation of a graph node."""
+
+    key: str
+    labels: Iterable[str]
+    properties: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class Relationship:
+    """Representation of a graph relationship."""
+
+    start: str
+    end: str
+    type: str
+    properties: Dict[str, str] = field(default_factory=dict)
+
+
+NODES: List[Node] = [
+    Node(
+        key="FastAPIApp",
+        labels=["Component", "FastAPI"],
+        properties={
+            "name": "FastAPI app.main",
+            "description": "Application entry point exposing REST and webhook routes.",
+        },
+    ),
+    Node(
+        key="ProcessAudioEndpoint",
+        labels=["Endpoint", "HTTP"],
+        properties={
+            "name": "POST /process-audio/",
+            "description": "Uploads audio, triggers STT and LLM pipeline, stores results.",
+        },
+    ),
+    Node(
+        key="ConversationRouter",
+        labels=["Endpoint", "Conversation"],
+        properties={
+            "name": "Conversation router",
+            "description": "Manages multi-turn dialogue, sessions and TTS responses.",
+        },
+    ),
+    Node(
+        key="TelephonyRouter",
+        labels=["Endpoint", "Telephony"],
+        properties={
+            "name": "Telephony router",
+            "description": "Handles Twilio/Sipgate webhooks and asynchronous audio downloads.",
+        },
+    ),
+    Node(
+        key="STTService",
+        labels=["Service", "STT"],
+        properties={
+            "name": "Speech-to-Text",
+            "description": "Transcribes audio recordings to text.",
+        },
+    ),
+    Node(
+        key="TranscriptArtifact",
+        labels=["Artifact"],
+        properties={
+            "name": "Transcript",
+            "description": "Text representation of recorded audio.",
+        },
+    ),
+    Node(
+        key="LLMService",
+        labels=["Service", "LLM"],
+        properties={
+            "name": "LLM extraction",
+            "description": "Extracts structured invoice context from transcripts.",
+        },
+    ),
+    Node(
+        key="InvoiceContext",
+        labels=["Domain", "Invoice"],
+        properties={
+            "name": "InvoiceContext",
+            "description": "Normalized invoice with customer, items, totals, and metadata.",
+        },
+    ),
+    Node(
+        key="PricingService",
+        labels=["Service", "Pricing"],
+        properties={
+            "name": "Pricing engine",
+            "description": "Applies default rates, taxes, and totals to invoice items.",
+        },
+    ),
+    Node(
+        key="BillingAdapter",
+        labels=["Service", "Integration"],
+        properties={
+            "name": "Billing adapter",
+            "description": "Sends invoices to downstream billing systems.",
+        },
+    ),
+    Node(
+        key="PersistenceService",
+        labels=["Service", "Persistence"],
+        properties={
+            "name": "Persistence",
+            "description": "Stores transcripts, PDFs, XML exports, and audio artifacts.",
+        },
+    ),
+    Node(
+        key="PDFGenerator",
+        labels=["Artifact", "PDF"],
+        properties={
+            "name": "PDF generator",
+            "description": "Produces invoice PDFs using ReportLab templates.",
+        },
+    ),
+    Node(
+        key="XRechnungGenerator",
+        labels=["Artifact", "XML"],
+        properties={
+            "name": "XRechnung generator",
+            "description": "Creates simplified XRechnung XML output.",
+        },
+    ),
+    Node(
+        key="TTSServices",
+        labels=["Service", "TTS"],
+        properties={
+            "name": "Text-to-Speech",
+            "description": "Generates spoken responses for dialogues and callbacks.",
+        },
+    ),
+    Node(
+        key="TelephonyIntegrations",
+        labels=["Integration", "Telephony"],
+        properties={
+            "name": "Twilio & Sipgate integrations",
+            "description": "Download recordings and trigger processing pipeline.",
+        },
+    ),
+    Node(
+        key="Downloader",
+        labels=["Service", "Utility"],
+        properties={
+            "name": "Recording downloader",
+            "description": "Fetches remote call recordings asynchronously.",
+        },
+    ),
+]
+
+
+RELATIONSHIPS: List[Relationship] = [
+    Relationship("FastAPIApp", "ProcessAudioEndpoint", "EXPOSES"),
+    Relationship("FastAPIApp", "ConversationRouter", "EXPOSES"),
+    Relationship("FastAPIApp", "TelephonyRouter", "EXPOSES"),
+    Relationship("ProcessAudioEndpoint", "STTService", "USES"),
+    Relationship("ProcessAudioEndpoint", "LLMService", "USES"),
+    Relationship("ProcessAudioEndpoint", "InvoiceContext", "CREATES"),
+    Relationship("ProcessAudioEndpoint", "PersistenceService", "PERSISTS"),
+    Relationship("STTService", "TranscriptArtifact", "PRODUCES"),
+    Relationship("LLMService", "InvoiceContext", "ENRICHES"),
+    Relationship("InvoiceContext", "PricingService", "USES"),
+    Relationship("InvoiceContext", "BillingAdapter", "DISPATCHES_TO"),
+    Relationship("PersistenceService", "TranscriptArtifact", "STORES"),
+    Relationship("PersistenceService", "PDFGenerator", "STORES"),
+    Relationship("PersistenceService", "XRechnungGenerator", "STORES"),
+    Relationship("ConversationRouter", "STTService", "USES"),
+    Relationship("ConversationRouter", "LLMService", "USES"),
+    Relationship("ConversationRouter", "InvoiceContext", "UPDATES"),
+    Relationship("ConversationRouter", "TTSServices", "USES"),
+    Relationship("TelephonyRouter", "TelephonyIntegrations", "DELEGATES_TO"),
+    Relationship("TelephonyRouter", "Downloader", "USES"),
+    Relationship("TelephonyRouter", "STTService", "USES"),
+    Relationship("TelephonyRouter", "LLMService", "USES"),
+    Relationship("TelephonyRouter", "InvoiceContext", "USES"),
+    Relationship("TelephonyRouter", "PersistenceService", "USES"),
+]
+
+
+def _merge_node(tx, node: Node) -> None:
+    labels = ":".join(node.labels)
+    query = (
+        f"MERGE (n:{labels} {{key: $key}}) "
+        "SET n += $properties"
+    )
+    tx.run(query, key=node.key, properties=node.properties)
+
+
+def _merge_relationship(tx, rel: Relationship) -> None:
+    query = (
+        "MATCH (start {key: $start_key}) "
+        "MATCH (end {key: $end_key}) "
+        "MERGE (start)-[r:%s]->(end) "
+        "SET r += $properties"
+    ) % rel.type
+    tx.run(query, start_key=rel.start, end_key=rel.end, properties=rel.properties)
+
+
+def load_graph(uri: str, user: str, password: str) -> None:
+    """Load graph metadata into Neo4j."""
+
+    driver = GraphDatabase.driver(uri, auth=(user, password))
+    LOGGER.info("Connecting to %s", uri)
+    with driver, driver.session() as session:
+        session.execute_write(lambda tx: [_merge_node(tx, node) for node in NODES])
+        session.execute_write(
+            lambda tx: [_merge_relationship(tx, rel) for rel in RELATIONSHIPS]
+        )
+    LOGGER.info("Graph successfully loaded.")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("uri", help="Neo4j bolt URI, e.g. bolt://localhost:7687")
+    parser.add_argument("user", help="Neo4j username")
+    parser.add_argument("password", help="Neo4j password")
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Set logging verbosity.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    logging.basicConfig(level=getattr(logging, args.log_level))
+    load_graph(args.uri, args.user, args.password)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a setup guide for running Neo4j locally and inspecting the project knowledge graph
- provide a Python helper script that loads the documented nodes and relationships into Neo4j

## Testing
- python -m compileall scripts/neo4j/load_knowledge_graph.py

------
https://chatgpt.com/codex/tasks/task_e_68d54e6c16a4832bbf39acac353857cf