### PR TITLE
Use Ollama phi3:mini as default local model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,10 +7,10 @@ MCP_ENDPOINT=http://localhost:8001
 # LLM configuration: 'openai' or 'ollama'
 LLM_PROVIDER=ollama
 # Model name for the chosen provider
-LLM_MODEL=deepseek-r1:latest
-# Für lokale Ollama-Nutzung empfehlen wir das Modell "deepseek-r1:latest"
-# Alternativ können kleinere Modelle wie "mistral", "llama3" oder "orca2" verwendet
-# werden, die weniger Ressourcen benötigen
+LLM_MODEL=phi3:mini
+# Für lokale Ollama-Nutzung empfehlen wir das Modell "phi3:mini"
+# Alternativ können Modelle wie "mistral", "llama3" oder "orca2" verwendet
+# werden, die weniger Ressourcen benötigen oder andere Eigenschaften bieten
 # Base URL for Ollama server
 OLLAMA_BASE_URL=http://localhost:11434
 # Timeout for Ollama requests in seconds (minimum 300)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ cp .env.example .env  # bei lokaler Nutzung ist kein OPENAI_API_KEY nötig
 # BILLING_ADAPTER=app.billing_adapters.sevdesk_mcp:SevDeskMCPAdapter
 # MCP_ENDPOINT=http://localhost:8001
 # LLM_PROVIDER=ollama|openai
-# LLM_MODEL=deepseek-r1:latest  # alternativ: llama3, orca2, mistral
+# LLM_MODEL=phi3:mini  # alternativ: llama3, orca2, mistral
 # STT_PROVIDER=whisper|openai|command
 # Für whisper/command muss ffmpeg als System-Binary installiert sein
 # z.B. "brew install ffmpeg" (macOS) oder "sudo apt install ffmpeg" (Ubuntu)
@@ -160,10 +160,10 @@ Dann in der `.env` folgende Einstellungen setzen:
 
 ```bash
 LLM_PROVIDER=ollama
-LLM_MODEL=deepseek-r1:latest
+LLM_MODEL=phi3:mini
 ```
 
-Das Modell `deepseek-r1:latest` liefert leistungsfähige Ergebnisse. Kleinere Modelle wie `mistral:latest`, `llama3:latest` oder `orca2:latest` funktionieren ebenfalls und benötigen weniger Ressourcen. `OLLAMA_BASE_URL` kann bei Bedarf angepasst werden. Der Timeout für Ollama-Anfragen beträgt standardmäßig 300 Sekunden und lässt sich über `OLLAMA_TIMEOUT` konfigurieren. Danach wie gewohnt `uvicorn` starten und Anfragen an `/process-audio/` senden.
+Das Modell `phi3:mini` liefert leistungsfähige Ergebnisse und benötigt dabei vergleichsweise wenig Ressourcen. Alternativ funktionieren Modelle wie `mistral:latest`, `llama3:latest` oder `orca2:latest` ebenfalls. `OLLAMA_BASE_URL` kann bei Bedarf angepasst werden. Der Timeout für Ollama-Anfragen beträgt standardmäßig 300 Sekunden und lässt sich über `OLLAMA_TIMEOUT` konfigurieren. Danach wie gewohnt `uvicorn` starten und Anfragen an `/process-audio/` senden.
 
 ## MacBook Pro: Lokale Ausführung mit Ollama
 

--- a/scripts/run_mac_ollama.sh
+++ b/scripts/run_mac_ollama.sh
@@ -17,7 +17,7 @@ fi
 
 # Lokale Provider verwenden
 export LLM_PROVIDER=ollama
-export LLM_MODEL=${LLM_MODEL:-deepseek-r1:latest}  # "mistral", "llama3" oder "orca2" funktionieren ebenfalls
+export LLM_MODEL=${LLM_MODEL:-phi3:mini}  # "mistral", "llama3" oder "orca2" funktionieren ebenfalls
 
 # STT_PROVIDER auf "whisper" setzen, falls nicht anders angegeben.
 STT_PROVIDER_DEFAULT=${STT_PROVIDER:-whisper}


### PR DESCRIPTION
## Summary
- document phi3:mini as the recommended Ollama model in the README and example environment file
- default the macOS helper script to phi3:mini when starting Ollama locally

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daac7f7040832bb116fb307fcfb8ce