### PR TITLE
Handle direct correction commands in conversation flow

### DIFF
--- a/app/conversation.py
+++ b/app/conversation.py
@@ -29,6 +29,8 @@ router = APIRouter()
 SESSIONS: Dict[str, List[Dict[str, str]]] = {}
 # Zuletzt erfolgreicher Rechnungszustand pro Session
 INVOICE_STATE: Dict[str, InvoiceContext] = {}
+# Fortschritt der jeweiligen Session (z. B. "collecting", "summarizing")
+SESSION_STATUS: Dict[str, str] = {}
 
 # Pfad zur Konfigurationsdatei
 ENV_PATH = Path(".env")
@@ -83,6 +85,20 @@ _MATERIAL_PRICE_PATTERN = re.compile(
 
 _MATERIAL_COUNT_PATTERN = re.compile(
     r"(\d+(?:[.,]\d+)?)\s*(?:x\s*)?([a-zäöüß][a-zäöüß-]*)",
+    re.IGNORECASE,
+)
+
+_ITEM_CORRECTION_PATTERN = re.compile(
+    r"position\s+(?P<index>\d+)\s+(?P<field>menge|preis|beschreibung)"
+    r"\s*(?:ist|auf|zu|soll(?:\s+sein)?|beträgt|=)?\s*(?P<value>.+)",
+    re.IGNORECASE,
+)
+_CUSTOMER_CORRECTION_PATTERN = re.compile(
+    r"kunde\s+(?:ist|heißt)\s+(?P<value>.+)",
+    re.IGNORECASE,
+)
+_SERVICE_CORRECTION_PATTERN = re.compile(
+    r"dienstleistung\s+(?:ist|lautet)\s+(?P<value>.+)",
     re.IGNORECASE,
 )
 
@@ -491,6 +507,102 @@ def fill_default_fields(invoice: InvoiceContext) -> None:
         invoice.service["description"] = "Dienstleistung nicht näher beschrieben"
 
 
+def _parse_number(value: str) -> float | None:
+    """Extrahiert eine Fließkommazahl aus einem Textfragment."""
+
+    if not value:
+        return None
+
+    compact = value.replace(" ", "").strip()
+    match = re.search(r"\d+(?:[.,]\d+)?", compact)
+    if not match:
+        return None
+
+    number = match.group(0)
+    normalized = number.replace(".", "").replace(",", ".")
+    try:
+        return float(normalized)
+    except ValueError:  # pragma: no cover - defensive
+        return None
+
+
+def _clean_command_value(value: str) -> str:
+    """Bereinigt extrahierte Werte aus Korrekturkommandos."""
+
+    if not value:
+        return ""
+
+    text = value.strip()
+    for sep in (". ", "! ", "? ", "; "):
+        idx = text.find(sep)
+        if idx != -1:
+            text = text[:idx]
+            break
+    text = text.strip()
+    return text.rstrip(".?!;").strip()
+
+
+def update_item_field(
+    invoice: InvoiceContext, index: int, field: str, value: str
+) -> tuple[bool, str]:
+    """Aktualisiert Menge, Preis oder Beschreibung einer Rechnungsposition."""
+
+    if not 1 <= index <= len(invoice.items):
+        return False, f"Position {index} konnte ich nicht finden."
+
+    item = invoice.items[index - 1]
+    field_key = field.casefold()
+
+    if field_key == "menge":
+        number = _parse_number(value)
+        if number is None:
+            return False, f"Die Menge für Position {index} konnte ich nicht verstehen."
+        item.quantity = number
+        message = f"Menge in Position {index} ist jetzt {number:g}"
+    elif field_key == "preis":
+        number = _parse_number(value)
+        if number is None:
+            return False, f"Den Preis für Position {index} konnte ich nicht verstehen."
+        item.unit_price = number
+        message = f"Preis in Position {index} ist jetzt {number:g} Euro"
+    elif field_key == "beschreibung":
+        text = value.strip()
+        if not text:
+            return False, "Bitte gib eine Beschreibung an."
+        item.description = text
+        message = f"Beschreibung in Position {index} aktualisiert"
+    else:  # pragma: no cover - defensive
+        return False, f"Feld '{field}' kann ich nicht anpassen."
+
+    apply_pricing(invoice)
+    fill_default_fields(invoice)
+    return True, message
+
+
+def update_customer_name(invoice: InvoiceContext, value: str) -> tuple[bool, str]:
+    """Aktualisiert den Kundennamen."""
+
+    name = value.strip()
+    if not name:
+        return False, "Bitte nenne einen Kundennamen."
+    invoice.customer["name"] = name
+    apply_pricing(invoice)
+    fill_default_fields(invoice)
+    return True, f"Kunde ist jetzt {name}"
+
+
+def update_service_description(invoice: InvoiceContext, value: str) -> tuple[bool, str]:
+    """Aktualisiert die Dienstleistungsbeschreibung."""
+
+    description = value.strip()
+    if not description:
+        return False, "Bitte nenne eine Dienstleistung."
+    invoice.service["description"] = description
+    apply_pricing(invoice)
+    fill_default_fields(invoice)
+    return True, f"Dienstleistung lautet jetzt {description}"
+
+
 def _normalize_worker_role(role: str | None) -> str | None:
     """Bringt Rollenbezeichnungen auf eine einheitliche Schreibweise."""
 
@@ -515,10 +627,91 @@ def _roles_from_transcript(transcript: str) -> set[str]:
     return roles
 
 
+def _handle_direct_corrections(session_id: str, transcript_part: str) -> dict | None:
+    """Verarbeitet erkannte Korrekturbefehle ohne LLM-Roundtrip."""
+
+    invoice = INVOICE_STATE.get(session_id)
+    if not invoice:
+        return None
+
+    text = transcript_part or ""
+    handled = False
+    updated = False
+    feedback: list[str] = []
+
+    for match in _ITEM_CORRECTION_PATTERN.finditer(text):
+        handled = True
+        idx = int(match.group("index"))
+        field = match.group("field")
+        raw_value = _clean_command_value(match.group("value"))
+        success, message = update_item_field(invoice, idx, field, raw_value)
+        feedback.append(message)
+        if success:
+            updated = True
+
+    customer_match = _CUSTOMER_CORRECTION_PATTERN.search(text)
+    if customer_match:
+        handled = True
+        raw = _clean_command_value(customer_match.group("value"))
+        success, message = update_customer_name(invoice, raw)
+        feedback.append(message)
+        if success:
+            updated = True
+
+    service_match = _SERVICE_CORRECTION_PATTERN.search(text)
+    if service_match:
+        handled = True
+        raw = _clean_command_value(service_match.group("value"))
+        success, message = update_service_description(invoice, raw)
+        feedback.append(message)
+        if success:
+            updated = True
+
+    if not handled:
+        return None
+
+    INVOICE_STATE[session_id] = invoice
+
+    def _ensure_period(message: str) -> str:
+        trimmed = message.strip()
+        if not trimmed:
+            return ""
+        if trimmed[-1] not in ".!?":
+            return trimmed + "."
+        return trimmed
+
+    spoken = " ".join(filter(None, (_ensure_period(msg) for msg in feedback)))
+    if updated:
+        SESSION_STATUS[session_id] = "collecting"
+        spoken = (spoken + " Ich fasse gleich neu zusammen.").strip()
+    else:
+        SESSION_STATUS.setdefault(session_id, "collecting")
+
+    session_msgs = SESSIONS.setdefault(session_id, [])
+    session_msgs.append({"role": "user", "content": transcript_part})
+
+    audio_b64 = base64.b64encode(text_to_speech(spoken)).decode("ascii")
+
+    current_transcript = " ".join(
+        m["content"] for m in session_msgs if m.get("role") == "user"
+    )
+
+    return {
+        "done": False,
+        "message": spoken,
+        "audio": audio_b64,
+        "invoice": invoice.model_dump(mode="json"),
+        "transcript": current_transcript,
+        "session_status": SESSION_STATUS.get(session_id, "collecting"),
+    }
+
+
 def _handle_conversation(
     session_id: str, transcript_part: str, audio_bytes: bytes
 ) -> dict:
     """Gemeinsame Logik für Sprach- und Texteingaben."""
+
+    SESSION_STATUS.setdefault(session_id, "collecting")
 
     # Prüft auf Konfigurationsbefehle wie "Speichere meinen Firmennamen".
     m = re.search(
@@ -553,6 +746,7 @@ def _handle_conversation(
             apply_pricing(invoice)
             INVOICE_STATE[session_id] = invoice
             message = f"Position {idx} gelöscht."
+            SESSION_STATUS[session_id] = "collecting"
         else:
             message = f"Position {idx} nicht gefunden."
         audio_b64 = base64.b64encode(text_to_speech(message)).decode("ascii")
@@ -565,7 +759,12 @@ def _handle_conversation(
             "audio": audio_b64,
             "transcript": SESSIONS.get(session_id, ""),
             "invoice": invoice.model_dump(mode="json") if invoice else None,
+            "session_status": SESSION_STATUS.get(session_id, "collecting"),
         }
+
+    correction = _handle_direct_corrections(session_id, transcript_part)
+    if correction:
+        return correction
 
     # Neues Transkript zur Session hinzufügen.
     session_msgs = SESSIONS.setdefault(session_id, [])
@@ -805,6 +1004,7 @@ def _handle_conversation(
     pdf_path = str(Path(log_dir) / "invoice.pdf")
     pdf_url = "/" + pdf_path.replace("\\", "/")
     audio_b64 = base64.b64encode(text_to_speech(message)).decode("ascii")
+    SESSION_STATUS[session_id] = "completed"
     return {
         "done": True,
         "message": message,

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -16,6 +16,7 @@ def test_conversation_provisional_invoice(monkeypatch, tmp_data_dir):
     """Generates a provisional invoice even with sparse input."""
     conversation.SESSIONS.clear()
     conversation.INVOICE_STATE.clear()
+    conversation.SESSION_STATUS.clear()
 
     transcripts = iter(["", "Hans Malen"])
     monkeypatch.setattr(conversation, "transcribe_audio", lambda b: next(transcripts))
@@ -86,6 +87,7 @@ def test_conversation_parse_error(monkeypatch, tmp_data_dir):
     """Even on parse errors a provisional invoice is returned."""
     conversation.SESSIONS.clear()
     conversation.INVOICE_STATE.clear()
+    conversation.SESSION_STATUS.clear()
     monkeypatch.setattr(conversation, "transcribe_audio", lambda b: "kaputt 7 km")
     monkeypatch.setattr(conversation, "extract_invoice_context", lambda t: "invalid")
     monkeypatch.setattr(conversation, "send_to_billing_system", lambda i: {"ok": True})
@@ -118,6 +120,7 @@ def test_conversation_parse_error_keeps_state(monkeypatch, tmp_data_dir):
     """Parse-Fehler sollen vorhandene Rechnungsdaten nicht verwerfen."""
     conversation.SESSIONS.clear()
     conversation.INVOICE_STATE.clear()
+    conversation.SESSION_STATUS.clear()
 
     transcripts = iter(["Hans Malen", "Nur eine Stunde"])
     monkeypatch.setattr(conversation, "transcribe_audio", lambda b: next(transcripts))
@@ -186,6 +189,7 @@ def test_conversation_store_company_name(monkeypatch, tmp_path):
     """Recognizes command to store company name in .env."""
     conversation.SESSIONS.clear()
     conversation.INVOICE_STATE.clear()
+    conversation.SESSION_STATUS.clear()
     env_file = tmp_path / ".env"
     monkeypatch.setattr(conversation, "ENV_PATH", env_file)
     monkeypatch.setattr(
@@ -214,6 +218,7 @@ def test_conversation_defaults(monkeypatch, tmp_data_dir):
     """Missing customer/service fields are filled with placeholders."""
     conversation.SESSIONS.clear()
     conversation.INVOICE_STATE.clear()
+    conversation.SESSION_STATUS.clear()
 
     monkeypatch.setattr(conversation, "transcribe_audio", lambda b: "Malen 100")
 
@@ -222,6 +227,7 @@ def test_conversation_estimates_labor_item(monkeypatch, tmp_data_dir):
     """Missing labor positions should be estimated automatically."""
     conversation.SESSIONS.clear()
     conversation.INVOICE_STATE.clear()
+    conversation.SESSION_STATUS.clear()
 
     monkeypatch.setattr(conversation, "transcribe_audio", lambda b: "Hans Dusche")
 
@@ -273,6 +279,7 @@ def test_conversation_extracts_hours_and_materials(monkeypatch, tmp_data_dir):
 
     conversation.SESSIONS.clear()
     conversation.INVOICE_STATE.clear()
+    conversation.SESSION_STATUS.clear()
 
     transcript = (
         "Bitte erstelle eine Rechnung für den Einbau einer Tür und 2 Fenstern bei "
@@ -346,6 +353,7 @@ def test_conversation_keeps_context_on_correction(monkeypatch, tmp_data_dir):
     """Corrections with invalid parse keep prior context."""
     conversation.SESSIONS.clear()
     conversation.INVOICE_STATE.clear()
+    conversation.SESSION_STATUS.clear()
 
     transcripts = iter(["Huber Fenster", "Nur eine Stunde"])
     monkeypatch.setattr(conversation, "transcribe_audio", lambda b: next(transcripts))
@@ -411,6 +419,7 @@ def test_conversation_ignores_auto_customer_name(monkeypatch, tmp_data_dir):
 
     conversation.SESSIONS.clear()
     conversation.INVOICE_STATE.clear()
+    conversation.SESSION_STATUS.clear()
 
     monkeypatch.setattr(conversation, "transcribe_audio", lambda b: "nur text")
 
@@ -443,6 +452,7 @@ def test_conversation_delete_position(monkeypatch):
     """Removes an invoice item when requested."""
     conversation.SESSIONS.clear()
     conversation.INVOICE_STATE.clear()
+    conversation.SESSION_STATUS.clear()
 
     session_id = "del"
     invoice = InvoiceContext(
@@ -493,3 +503,108 @@ def test_conversation_delete_position(monkeypatch):
     assert len(invoice.items) == 1
     assert invoice.items[0].description == "Neu"
     assert invoice.amount["total"] == pytest.approx(11.9, abs=0.01)
+
+
+def test_conversation_direct_price_correction(monkeypatch):
+    """Recognizes corrections like 'Position 1 Preis ...'."""
+
+    conversation.SESSIONS.clear()
+    conversation.INVOICE_STATE.clear()
+    conversation.SESSION_STATUS.clear()
+
+    session_id = "corr-price"
+    invoice = InvoiceContext(
+        type="InvoiceContext",
+        customer={"name": "Kunde"},
+        service={"description": "Service"},
+        items=[
+            InvoiceItem(
+                description="Arbeitszeit",
+                category="labor",
+                quantity=1.0,
+                unit="h",
+                unit_price=40.0,
+                worker_role="Geselle",
+            )
+        ],
+        amount={},
+    )
+    apply_pricing(invoice)
+    conversation.INVOICE_STATE[session_id] = invoice
+
+    monkeypatch.setattr(conversation, "text_to_speech", lambda t: b"mp3")
+    monkeypatch.setattr(
+        conversation,
+        "extract_invoice_context",
+        lambda t: pytest.fail("LLM merge should not run for direct corrections"),
+    )
+
+    client = TestClient(app)
+    resp = client.post(
+        "/conversation-text/",
+        data={"session_id": session_id, "text": "Position 1 Preis ist 150 Euro"},
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["done"] is False
+    assert "preis" in data["message"].lower()
+    assert "zusammen" in data["message"].lower()
+    assert data["invoice"]["items"][0]["unit_price"] == 150.0
+    assert data["session_status"] == "collecting"
+
+    invoice_state = conversation.INVOICE_STATE[session_id]
+    assert invoice_state.items[0].unit_price == 150.0
+    assert conversation.SESSION_STATUS[session_id] == "collecting"
+
+
+def test_conversation_direct_customer_correction(monkeypatch):
+    """Updates customer name via explicit correction command."""
+
+    conversation.SESSIONS.clear()
+    conversation.INVOICE_STATE.clear()
+    conversation.SESSION_STATUS.clear()
+
+    session_id = "corr-customer"
+    invoice = InvoiceContext(
+        type="InvoiceContext",
+        customer={"name": ""},
+        service={"description": "Service"},
+        items=[
+            InvoiceItem(
+                description="Arbeitszeit",
+                category="labor",
+                quantity=1.0,
+                unit="h",
+                unit_price=40.0,
+                worker_role="Geselle",
+            )
+        ],
+        amount={},
+    )
+    apply_pricing(invoice)
+    conversation.INVOICE_STATE[session_id] = invoice
+
+    monkeypatch.setattr(conversation, "text_to_speech", lambda t: b"mp3")
+    monkeypatch.setattr(
+        conversation,
+        "extract_invoice_context",
+        lambda t: pytest.fail("LLM merge should not run for direct corrections"),
+    )
+
+    client = TestClient(app)
+    resp = client.post(
+        "/conversation-text/",
+        data={"session_id": session_id, "text": "Kunde ist Familie Müller."},
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["done"] is False
+    assert "kunde ist" in data["message"].lower()
+    assert data["invoice"]["customer"]["name"] == "Familie Müller"
+    assert data["session_status"] == "collecting"
+
+    invoice_state = conversation.INVOICE_STATE[session_id]
+    assert invoice_state.customer["name"] == "Familie Müller"
+    assert conversation.SESSION_STATUS[session_id] == "collecting"


### PR DESCRIPTION
## Summary
- add session status tracking and regex-based detection for invoice corrections
- update invoices directly when correction commands are recognized and confirm changes in audio feedback
- cover direct correction handling with new conversation tests and reset session status in existing cases

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbbffd523c832baafeb880c3e85991